### PR TITLE
Changes for openfst-feedstock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,55 @@
+
+cmake_minimum_required(VERSION 3.20)
+project(openfst)
+
+include(GNUInstallDirs)
+include(GenerateExportHeader)
+set(CMAKE_MACOSX_RPATH 1)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+if (MSVC)
+    find_package(dlfcn-win32 REQUIRED)
+    set(CMAKE_DL_LIBS dlfcn-win32::dl)
+    set(CMAKE_ENABLE_EXPORTS ON)
+
+    #set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    add_definitions(-DWIN32_LEAN_AND_MEAN)
+    add_definitions(-DNOMINMAX)
+    add_definitions(-D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
+    add_definitions(-D_USE_MATH_DEFINES)
+    add_compile_options(/permissive- /FS /wd4819 /EHsc /bigobj)
+
+    # some warnings related with fst
+    add_compile_options(/wd4018 /wd4244 /wd4267 /wd4291 /wd4305)
+    
+endif (MSVC)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+set(SOVERSION "26")
+
+
+option(HAVE_BIN          "Build the fst binaries" ON)
+option(HAVE_SCRIPT       "Build the fstscript" ON)
+option(HAVE_COMPACT      "Build compact" ON)
+option(HAVE_COMPRESS "Build compress" ON)
+option(HAVE_CONST   "Build const" ON)
+option(HAVE_FAR  "Build far" ON)
+option(HAVE_GRM "Build grm" ON)
+option(HAVE_PDT "Build pdt" ON)
+option(HAVE_MPDT "Build mpdt" ON)
+option(HAVE_LINEAR "Build linear" ON)
+option(HAVE_LOOKAHEAD "Build lookahead" ON)
+option(HAVE_NGRAM "Build ngram" ON)
+option(HAVE_PYTHON "Build python" OFF)
+option(HAVE_SPECIAL "Build special" ON)
+option(OPENFST_BUILD_TEST "Build tests" ON) 
+
+if (OPENFST_BUILD_TEST)
+    include(CTest)
+    enable_testing()
+    set(CTEST_OUTPUT_ON_FAILURE ON)
+endif()
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,20 @@
+#-DHAVE_CONFIG_H -I./../include -fno-exceptions -funsigned-char -std=c++11 -MT symbol-table.lo -MD -MP -MF .deps/symbol-table.Tpo -c symbol-table.cc  -fno-common -DPIC -o .libs/symbol-table.o
+
+include_directories(./include/)
+install(DIRECTORY include/ DESTINATION include/
+        FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY include/ DESTINATION include/
+        FILES_MATCHING PATTERN "*.inc")
+
+add_subdirectory(lib)
+add_subdirectory(script)
+
+if(HAVE_BIN)
+  add_subdirectory(bin)
+endif(HAVE_BIN)
+
+add_subdirectory(extensions)
+
+if (${OPENFST_BUILD_TEST})
+add_subdirectory(test)
+endif()

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -1,0 +1,85 @@
+function (add_executable2 _name)
+    add_executable(${ARGV})
+    if (TARGET ${_name})
+        target_link_libraries(${_name} fstscript fst ${CMAKE_DL_LIBS})
+        set_target_properties(${_name} PROPERTIES FOLDER bin)
+    endif()
+
+    install(TARGETS ${_name} RUNTIME DESTINATION bin)
+endfunction()
+
+include_directories(../include ../script/)
+
+add_executable2(fstarcsort fstarcsort-main.cc fstarcsort.cc)
+
+add_executable2(fstclosure fstclosure-main.cc fstclosure.cc)
+
+add_executable2(fstcompile  fstcompile-main.cc fstcompile.cc)
+
+add_executable2(fstcompose fstcompose-main.cc fstcompose.cc)
+
+add_executable2(fstconcat fstconcat-main.cc fstconcat.cc)
+
+add_executable2(fstconnect fstconnect-main.cc fstconnect.cc)
+
+add_executable2(fstconvert fstconvert-main.cc fstconvert.cc)
+
+add_executable2(fstdeterminize fstdeterminize-main.cc fstdeterminize.cc)
+
+add_executable2(fstdifference fstdifference-main.cc fstdifference.cc)
+
+add_executable2(fstdisambiguate fstdisambiguate-main.cc fstdisambiguate.cc)
+
+add_executable2(fstdraw fstdraw-main.cc fstdraw.cc)
+
+add_executable2(fstencode fstencode-main.cc fstencode.cc)
+
+add_executable2(fstepsnormalize fstepsnormalize-main.cc fstepsnormalize.cc)
+
+add_executable2(fstequal fstequal-main.cc fstequal.cc)
+
+add_executable2(fstequivalent fstequivalent-main.cc fstequivalent.cc)
+
+add_executable2(fstinfo fstinfo-main.cc fstinfo.cc)
+
+add_executable2(fstintersect fstintersect-main.cc fstintersect.cc)
+
+add_executable2(fstinvert fstinvert-main.cc fstinvert.cc)
+
+add_executable2(fstisomorphic fstisomorphic-main.cc fstisomorphic.cc)
+
+add_executable2(fstmap fstmap-main.cc fstmap.cc)
+
+add_executable2(fstminimize fstminimize-main.cc fstminimize.cc)
+
+add_executable2(fstprint fstprint-main.cc fstprint.cc)
+
+add_executable2(fstproject fstproject-main.cc fstproject.cc)
+
+add_executable2(fstprune fstprune-main.cc fstprune.cc)
+
+add_executable2(fstpush fstpush-main.cc fstpush.cc)
+
+add_executable2(fstrandgen fstrandgen-main.cc fstrandgen.cc)
+
+add_executable2(fstrelabel fstrelabel-main.cc fstrelabel.cc)
+
+add_executable2(fstreplace fstreplace-main.cc fstreplace.cc)
+
+add_executable2(fstreverse fstreverse-main.cc fstreverse.cc)
+
+add_executable2(fstreweight fstreweight-main.cc fstreweight.cc)
+
+add_executable2(fstrmepsilon fstrmepsilon-main.cc fstrmepsilon.cc)
+
+add_executable2(fstshortestdistance fstshortestdistance-main.cc fstshortestdistance.cc)
+
+add_executable2(fstshortestpath fstshortestpath-main.cc fstshortestpath.cc)
+
+add_executable2(fstsymbols fstsymbols-main.cc fstsymbols.cc)
+
+add_executable2(fstsynchronize fstsynchronize-main.cc fstsynchronize.cc)
+
+add_executable2(fsttopsort fsttopsort-main.cc fsttopsort.cc)
+
+add_executable2(fstunion fstunion-main.cc fstunion.cc)

--- a/src/bin/fstcompile-main.cc
+++ b/src/bin/fstcompile-main.cc
@@ -57,7 +57,7 @@ int fstcompile_main(int argc, char **argv) {
   std::string source = "standard input";
   std::ifstream fstrm;
   if (argc > 1 && strcmp(argv[1], "-") != 0) {
-    fstrm.open(argv[1]);
+    fstrm.open(argv[1], std::ios_base::in | std::ios_base::binary);
     if (!fstrm) {
       LOG(ERROR) << argv[0] << ": Open failed, file = " << argv[1];
       return 1;

--- a/src/bin/fstdraw-main.cc
+++ b/src/bin/fstdraw-main.cc
@@ -72,7 +72,7 @@ int fstdraw_main(int argc, char **argv) {
       argc > 2 && strcmp(argv[2], "-") != 0 ? argv[2] : "";
   std::ofstream fstrm;
   if (!out_name.empty()) {
-    fstrm.open(out_name);
+    fstrm.open(out_name, std::ios_base::out | std::ios_base::binary);
     if (!fstrm) {
       LOG(ERROR) << argv[0] << ": Open failed, file = " << out_name;
       return 1;

--- a/src/bin/fstprint-main.cc
+++ b/src/bin/fstprint-main.cc
@@ -67,7 +67,7 @@ int fstprint_main(int argc, char **argv) {
   std::string dest = "standard output";
   std::ofstream fstrm;
   if (argc == 3) {
-    fstrm.open(argv[2]);
+    fstrm.open(argv[2], std::ios_base::out | std::ios_base::binary);
     if (!fstrm) {
       LOG(ERROR) << argv[0] << ": Open failed, file = " << argv[2];
       return 1;

--- a/src/extensions/CMakeLists.txt
+++ b/src/extensions/CMakeLists.txt
@@ -1,0 +1,43 @@
+if(HAVE_COMPACT)
+  add_subdirectory(compact)
+endif(HAVE_COMPACT)
+
+if(HAVE_COMPRESS)
+  add_subdirectory(compress)
+endif(HAVE_COMPRESS)
+
+if(HAVE_CONST)
+  add_subdirectory(const)
+endif(HAVE_CONST)
+
+if(HAVE_FAR OR HAVE_GRM)
+  add_subdirectory(far)
+endif(HAVE_FAR OR HAVE_GRM)
+
+if(HAVE_LINEAR)
+  add_subdirectory(linear)
+endif(HAVE_LINEAR)
+
+if(HAVE_LOOKAHEAD)
+  add_subdirectory(lookahead)
+endif(HAVE_LOOKAHEAD)
+
+if(HAVE_MPDT OR HAVE_GRM)
+  add_subdirectory(mpdt)
+endif(HAVE_MPDT OR HAVE_GRM)
+
+if(HAVE_NGRAM)
+  add_subdirectory(ngram)
+endif(HAVE_NGRAM)
+
+if(HAVE_PYTHON)
+  add_subdirectory(python)
+endif(HAVE_PYTHON)
+
+if(HAVE_PDT OR HAVE_MPDT OR HAVE_GRM)
+  add_subdirectory(pdt)
+endif(HAVE_PDT OR HAVE_MPDT OR HAVE_GRM)
+
+if(HAVE_SPECIAL)
+  add_subdirectory(special)
+endif(HAVE_SPECIAL)

--- a/src/extensions/compact/CMakeLists.txt
+++ b/src/extensions/compact/CMakeLists.txt
@@ -1,0 +1,103 @@
+add_library(fstcompact
+  compact8_acceptor-fst.cc 
+  compact8_string-fst.cc 
+  compact8_unweighted-fst.cc 
+  compact8_unweighted_acceptor-fst.cc 
+  compact8_weighted_string-fst.cc 
+  compact16_acceptor-fst.cc 
+  compact16_string-fst.cc 
+  compact16_unweighted-fst.cc 
+  compact16_unweighted_acceptor-fst.cc 
+  compact16_weighted_string-fst.cc 
+  compact64_acceptor-fst.cc 
+  compact64_string-fst.cc 
+  compact64_unweighted-fst.cc 
+  compact64_unweighted_acceptor-fst.cc 
+  compact64_weighted_string-fst.cc
+)
+
+target_link_libraries(fstcompact fst)
+set_target_properties(fstcompact PROPERTIES 
+  SOVERSION "${SOVERSION}"
+)
+GENERATE_EXPORT_HEADER( fstcompact
+             BASE_NAME fstcompact
+             EXPORT_MACRO_NAME fstcompact_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstcompact_Export.h
+             STATIC_DEFINE fstcompact_BUILT_AS_STATIC
+)
+target_compile_definitions(fstcompact PRIVATE fstcompact_EXPORTS)
+target_include_directories(fstcompact PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+
+install(TARGETS fstcompact 
+	        LIBRARY DESTINATION lib
+			ARCHIVE DESTINATION lib
+            RUNTIME DESTINATION bin
+)
+
+function (add_module _name)
+    add_library(${ARGV})
+    if (TARGET ${_name})
+        target_link_libraries(${_name} fst)
+    endif()
+
+    #set_target_properties(${_name} PROPERTIES SOVERSION "1")
+    if (MSVC)
+    install(TARGETS ${_name} 
+	        LIBRARY DESTINATION bin
+			ARCHIVE DESTINATION bin
+            RUNTIME DESTINATION bin)
+    else()
+    install(TARGETS ${_name} 
+	        LIBRARY DESTINATION lib
+			ARCHIVE DESTINATION lib
+            RUNTIME DESTINATION bin)
+    endif()
+endfunction()
+
+add_module(compact8_acceptor-fst MODULE
+  compact8_acceptor-fst.cc)
+ 
+add_module(compact8_string-fst MODULE
+  compact8_string-fst.cc)
+ 
+add_module(compact8_unweighted-fst MODULE
+  compact8_unweighted-fst.cc)
+ 
+add_module(compact8_unweighted_acceptor-fst MODULE
+  compact8_unweighted_acceptor-fst.cc)
+ 
+add_module(compact8_weighted_string-fst MODULE
+  compact8_weighted_string-fst.cc)
+ 
+add_module(compact16_acceptor-fst MODULE
+  compact16_acceptor-fst.cc)
+ 
+add_module(compact16_string-fst MODULE
+  compact16_string-fst.cc)
+ 
+add_module(compact16_unweighted-fst MODULE
+  compact16_unweighted-fst.cc)
+ 
+add_module(compact16_unweighted_acceptor-fst MODULE
+  compact16_unweighted_acceptor-fst.cc)
+ 
+add_module(compact16_weighted_string-fst MODULE
+  compact16_weighted_string-fst.cc)
+ 
+add_module(compact64_acceptor-fst MODULE
+  compact64_acceptor-fst.cc)
+ 
+add_module(compact64_string-fst MODULE
+  compact64_string-fst.cc)
+ 
+add_module(compact64_unweighted-fst MODULE
+  compact64_unweighted-fst.cc)
+ 
+add_module(compact64_unweighted_acceptor-fst MODULE
+  compact64_unweighted_acceptor-fst.cc)
+ 
+add_module(compact64_weighted_string-fst MODULE
+  compact64_weighted_string-fst.cc)
+

--- a/src/extensions/compress/CMakeLists.txt
+++ b/src/extensions/compress/CMakeLists.txt
@@ -1,0 +1,59 @@
+
+add_library(fstcompressscript
+  compressscript.cc
+ )
+if (MSVC)
+  target_link_libraries(fstcompressscript
+    fstscript
+    fst
+  )
+GENERATE_EXPORT_HEADER( fstcompressscript
+             BASE_NAME fstcompressscript
+             EXPORT_MACRO_NAME fstcompressscript_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstcompressscript_Export.h
+             STATIC_DEFINE fstcompressscript_BUILT_AS_STATIC
+)
+target_compile_definitions(fstcompressscript PRIVATE fstcompressscript_EXPORTS)
+target_include_directories(fstcompressscript PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+else()
+  target_link_libraries(fstcompressscript
+    fstscript
+    fst
+  )
+endif()
+set_target_properties(fstcompressscript PROPERTIES
+  SOVERSION "${SOVERSION}"
+)
+install(TARGETS fstcompressscript
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+ )
+
+if(HAVE_BIN)
+  add_executable(fstcompress
+    fstcompress.cc
+    fstcompress-main.cc)
+
+    if (MSVC)
+      target_link_libraries(fstcompress
+        fstcompressscript
+        fstscript
+        fst
+      )
+    else()
+      target_link_libraries(fstcompress
+        fstcompressscript
+        fstscript
+        fst
+        ${CMAKE_DL_LIBS}
+      )
+    endif()
+
+  install(TARGETS fstcompress
+	        LIBRARY DESTINATION lib
+			ARCHIVE DESTINATION lib
+            RUNTIME DESTINATION bin
+		)
+endif(HAVE_BIN)

--- a/src/extensions/const/CMakeLists.txt
+++ b/src/extensions/const/CMakeLists.txt
@@ -1,0 +1,49 @@
+function (add_module _name)
+    add_library(${ARGV})
+    if (TARGET ${_name})
+        target_link_libraries(${_name} fst)
+    endif()
+
+    if (MSVC)
+    install(TARGETS ${_name} 
+	        LIBRARY DESTINATION bin
+			ARCHIVE DESTINATION bin
+            RUNTIME DESTINATION bin)
+    else()
+    install(TARGETS ${_name} 
+	        LIBRARY DESTINATION lib
+			ARCHIVE DESTINATION lib
+            RUNTIME DESTINATION bin)
+    endif()
+endfunction()
+
+
+add_module(const8-fst MODULE const8-fst.cc)
+
+add_module(const16-fst MODULE const16-fst.cc)
+
+add_module(const64-fst MODULE const64-fst.cc)
+
+add_library(fstconst 
+  const8-fst.cc 
+  const16-fst.cc 
+  const64-fst.cc)
+target_link_libraries(fstconst fst)
+set_target_properties(fstconst PROPERTIES
+  SOVERSION "${SOVERSION}"
+)
+GENERATE_EXPORT_HEADER( fstconst
+             BASE_NAME fstconst
+             EXPORT_MACRO_NAME fstconst_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstconst_Export.h
+             STATIC_DEFINE fstconst_BUILT_AS_STATIC
+)
+target_compile_definitions(fstconst PRIVATE fstconst_EXPORTS)
+target_include_directories(fstconst PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+
+install(TARGETS fstconst 
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+ )

--- a/src/extensions/far/CMakeLists.txt
+++ b/src/extensions/far/CMakeLists.txt
@@ -1,0 +1,77 @@
+
+add_library(fstfar
+  sttable.cc
+  stlist.cc
+)
+target_link_libraries(fstfar fst)
+set_target_properties(fstfar PROPERTIES 
+  SOVERSION "${SOVERSION}"
+  FOLDER far
+)
+GENERATE_EXPORT_HEADER( fstfar
+             BASE_NAME fstfar
+             EXPORT_MACRO_NAME fstfar_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstfar_Export.h
+             STATIC_DEFINE fstfar_BUILT_AS_STATIC
+)
+target_compile_definitions(fstfar PRIVATE fstfar_EXPORTS)
+target_include_directories(fstfar PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+
+install(TARGETS fstfar
+LIBRARY DESTINATION lib
+ARCHIVE DESTINATION lib
+RUNTIME DESTINATION bin
+)
+
+if(HAVE_SCRIPT)
+  add_library(fstfarscript
+    compile-strings.cc 
+    far-class.cc 
+    farscript.cc
+    getters.cc 
+    script-impl.cc
+  )
+  if (MSVC)
+GENERATE_EXPORT_HEADER( fstfarscript
+             BASE_NAME fstfarscript
+             EXPORT_MACRO_NAME fstfarscript_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstfarscript_Export.h
+             STATIC_DEFINE fstfarscript_BUILT_AS_STATIC
+)
+target_compile_definitions(fstfarscript PRIVATE fstfarscript_EXPORTS)
+target_include_directories(fstfarscript PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+  endif()
+    target_link_libraries(fstfarscript fstfar fstscript fst ${CMAKE_DL_LIBS})
+  set_target_properties(fstfarscript PROPERTIES 
+    SOVERSION "${SOVERSION}"
+  )
+
+  install(TARGETS fstfarscript
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  )
+endif(HAVE_SCRIPT)
+
+if(HAVE_BIN)
+  function (add_executable2 _name)
+      add_executable(${ARGV})
+      if (TARGET ${_name})
+        target_link_libraries(${_name} fstfarscript fstscript fst ${CMAKE_DL_LIBS})
+      endif()
+      install(TARGETS ${_name} RUNTIME DESTINATION bin)
+  endfunction()
+
+  add_executable2(farcompilestrings farcompilestrings.cc farcompilestrings-main.cc)
+  add_executable2(farcreate  farcreate.cc farcreate-main.cc)
+  add_executable2(farconvert  farconvert.cc farconvert-main.cc)
+  add_executable2(farencode  farencode.cc farencode-main.cc)
+  add_executable2(farequal  farequal.cc farequal-main.cc)
+  add_executable2(farextract  farextract.cc farextract-main.cc)
+  add_executable2(farinfo  farinfo.cc farinfo-main.cc)
+  add_executable2(farisomorphic  farisomorphic.cc  farisomorphic-main.cc)
+  add_executable2(farprintstrings  farprintstrings.cc farprintstrings-main.cc)
+endif(HAVE_BIN)
+

--- a/src/extensions/far/compile-strings.cc
+++ b/src/extensions/far/compile-strings.cc
@@ -36,7 +36,7 @@ namespace internal {
 // number, or zero if the number of lines could not be determined because the
 // file was not seekable.
 int KeySize(std::string_view source) {
-  std::ifstream istrm(std::string{source});
+  std::ifstream istrm(std::string{source}, std::ios_base::in | std::ios_base::binary);
   istrm.seekg(0);
   // TODO(jrosenstock): Change this to is_regular_file when <filesystem> is
   // no longer banned.

--- a/src/extensions/far/farcompilestrings-main.cc
+++ b/src/extensions/far/farcompilestrings-main.cc
@@ -63,7 +63,7 @@ int farcompilestrings_main(int argc, char **argv) {
   std::vector<std::string> sources;
   if (FST_FLAGS_file_list_input) {
     for (int i = 1; i < argc - 1; ++i) {
-      std::ifstream istrm(argv[i]);
+      std::ifstream istrm(argv[i], std::ios_base::in | std::ios_base::binary);
       std::string str;
       while (std::getline(istrm, str)) sources.push_back(str);
     }

--- a/src/extensions/far/sttable.cc
+++ b/src/extensions/far/sttable.cc
@@ -27,7 +27,7 @@
 namespace fst {
 
 bool IsSTTable(std::string_view source) {
-  std::ifstream strm((std::string(source)));
+  std::ifstream strm((std::string(source)), std::ios_base::in | std::ios_base::binary);
   if (!strm.good()) return false;
 
   int32_t magic_number = 0;

--- a/src/extensions/linear/CMakeLists.txt
+++ b/src/extensions/linear/CMakeLists.txt
@@ -1,0 +1,88 @@
+
+
+if(HAVE_SCRIPT)
+  add_library(fstlinearscript
+    linearscript.cc
+  )
+  set_target_properties(fstlinearscript PROPERTIES 
+    SOVERSION "${SOVERSION}"
+  )
+    target_link_libraries(fstlinearscript
+      fstscript
+      fst
+    )
+  if (MSVC)
+GENERATE_EXPORT_HEADER( fstlinearscript
+             BASE_NAME fstlinearscript
+             EXPORT_MACRO_NAME fstlinearscript_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstlinearscript_Export.h
+             STATIC_DEFINE fstlinearscript_BUILT_AS_STATIC
+)
+target_compile_definitions(fstlinearscript PRIVATE fstlinearscript_EXPORTS)
+target_include_directories(fstlinearscript PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+    install(TARGETS fstlinearscript
+    LIBRARY DESTINATION bin
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    )
+  else()
+    install(TARGETS fstlinearscript
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    )
+  endif()
+  
+endif(HAVE_SCRIPT)
+
+if(HAVE_BIN)
+  add_executable(fstlinear
+    fstlinear.cc 
+    fstlinear-main.cc)
+    target_link_libraries(fstlinear
+      fstlinearscript
+      fstscript 
+      fst
+      ${CMAKE_DL_LIBS}
+    )
+
+  add_executable(fstloglinearapply
+    fstloglinearapply.cc 
+    fstloglinearapply-main.cc)
+  target_link_libraries(fstloglinearapply
+    fstlinearscript
+    fstscript 
+    fst
+    ${CMAKE_DL_LIBS}
+  )
+  install(TARGETS fstlinear fstloglinearapply
+    RUNTIME DESTINATION bin
+  )
+endif(HAVE_BIN)
+
+
+function (add_module _name)
+    add_library(${ARGV})
+    if (TARGET ${_name})
+        target_link_libraries(${_name} fst)
+    endif()
+
+    if (MSVC)
+      install(TARGETS ${_name}
+      LIBRARY DESTINATION bin
+      ARCHIVE DESTINATION bin
+      RUNTIME DESTINATION bin)
+    else()
+      install(TARGETS ${_name}
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib
+      RUNTIME DESTINATION bin)
+    endif()
+endfunction()
+
+add_module(linear-tagger-fst MODULE
+  linear-tagger-fst.cc)
+
+add_module(linear-classifier-fst MODULE
+  linear-classifier-fst.cc)

--- a/src/extensions/linear/linearscript.cc
+++ b/src/extensions/linear/linearscript.cc
@@ -82,7 +82,7 @@ REGISTER_FST_OPERATION_3ARCS(LinearCompileTpl, LinearCompileArgs);
 
 void SplitByWhitespace(const std::string &str, std::vector<std::string> *out) {
   out->clear();
-  std::istringstream strm(str);
+  std::istringstream strm(str, std::ios_base::in | std::ios_base::binary);
   std::string buf;
   while (strm >> buf) out->push_back(buf);
 }

--- a/src/extensions/lookahead/CMakeLists.txt
+++ b/src/extensions/lookahead/CMakeLists.txt
@@ -1,0 +1,43 @@
+add_library(fstlookahead
+  arc_lookahead-fst.cc 
+  ilabel_lookahead-fst.cc
+  olabel_lookahead-fst.cc
+)
+target_link_libraries(fstlookahead fst)
+set_target_properties(fstlookahead PROPERTIES 
+  SOVERSION "${SOVERSION}"
+)
+
+install(TARGETS fstlookahead 
+LIBRARY DESTINATION lib
+ARCHIVE DESTINATION lib
+RUNTIME DESTINATION bin
+)
+  
+function (add_module _name)
+    add_library(${ARGV})
+    if (TARGET ${_name})
+        target_link_libraries(${_name} fst)
+    endif()
+
+    if (MSVC)
+    install(TARGETS ${_name} 
+	        LIBRARY DESTINATION bin
+			ARCHIVE DESTINATION bin
+            RUNTIME DESTINATION bin)
+    else()
+    install(TARGETS ${_name} 
+	        LIBRARY DESTINATION lib
+			ARCHIVE DESTINATION lib
+            RUNTIME DESTINATION bin)
+    endif()
+endfunction()
+  
+add_module(arc_lookahead-fst MODULE
+  arc_lookahead-fst.cc)
+ 
+add_module(ilabel_lookahead-fst MODULE
+  ilabel_lookahead-fst.cc)
+
+add_module(olabel_lookahead-fst MODULE
+  olabel_lookahead-fst.cc)

--- a/src/extensions/mpdt/CMakeLists.txt
+++ b/src/extensions/mpdt/CMakeLists.txt
@@ -1,0 +1,38 @@
+
+if(HAVE_SCRIPT)
+  add_library(fstmpdtscript mpdtscript.cc)
+    target_link_libraries(fstmpdtscript fstscript fst)
+  if (MSVC)
+GENERATE_EXPORT_HEADER( fstmpdtscript
+             BASE_NAME fstmpdtscript
+             EXPORT_MACRO_NAME fstmpdtscript_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstmpdtscript_Export.h
+             STATIC_DEFINE fstmpdtscript_BUILT_AS_STATIC
+)
+target_compile_definitions(fstmpdtscript PUBLIC fstmpdtscript_EXPORTS)
+target_include_directories(fstmpdtscript PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+  endif()
+  set_target_properties(fstmpdtscript PROPERTIES 
+    SOVERSION "${SOVERSION}"
+  )
+  install(TARGETS fstmpdtscript 
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  )
+endif(HAVE_SCRIPT)
+
+if(HAVE_BIN)
+  function (add_executable2 _name)
+      add_executable(${ARGV})
+      if (TARGET ${_name})
+          target_link_libraries(${_name} fstmpdtscript fstpdtscript fstscript fst ${CMAKE_DL_LIBS})
+      endif()
+    install(TARGETS ${_name} RUNTIME DESTINATION bin)
+  endfunction()
+  add_executable2(mpdtcompose  mpdtcompose.cc mpdtcompose-main.cc)
+  add_executable2(mpdtexpand  mpdtexpand.cc mpdtexpand-main.cc)
+  add_executable2(mpdtinfo  mpdtinfo.cc mpdtinfo-main.cc)
+  add_executable2(mpdtreverse  mpdtreverse.cc mpdtreverse-main.cc)
+endif(HAVE_BIN)

--- a/src/extensions/ngram/CMakeLists.txt
+++ b/src/extensions/ngram/CMakeLists.txt
@@ -1,0 +1,54 @@
+
+add_library(fstngram
+    bitmap-index.cc 
+    ngram-fst.cc 
+    nthbit.cc
+)
+
+target_link_libraries(fstngram
+    fst
+)
+GENERATE_EXPORT_HEADER( fstngram
+             BASE_NAME fstngram
+             EXPORT_MACRO_NAME fstngram_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstngram_Export.h
+             STATIC_DEFINE fstngram_BUILT_AS_STATIC
+)
+target_compile_definitions(fstngram PRIVATE fstngram_EXPORTS)
+target_include_directories(fstngram PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+
+set_target_properties(fstngram PROPERTIES
+  SOVERSION "${SOVERSION}"
+)
+
+install(TARGETS fstngram 
+LIBRARY DESTINATION lib
+ARCHIVE DESTINATION lib
+RUNTIME DESTINATION bin
+)
+
+add_library(ngram_fst MODULE
+    bitmap-index.cc 
+    ngram-fst.cc 
+    nthbit.cc
+)
+
+target_link_libraries(ngram_fst
+    fst
+)
+target_compile_definitions(ngram_fst PRIVATE fstngram_EXPORTS)
+target_include_directories(ngram_fst PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+
+if (MSVC)
+install(TARGETS ${_name} 
+        LIBRARY DESTINATION bin
+        ARCHIVE DESTINATION bin
+        RUNTIME DESTINATION bin)
+else()
+install(TARGETS ${_name} 
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin)
+endif()

--- a/src/extensions/pdt/CMakeLists.txt
+++ b/src/extensions/pdt/CMakeLists.txt
@@ -1,0 +1,44 @@
+
+
+if(HAVE_SCRIPT)
+  add_library(fstpdtscript getters.cc pdtscript.cc)
+    target_link_libraries(fstpdtscript fstscript fst)
+  if (MSVC)
+GENERATE_EXPORT_HEADER( fstpdtscript
+             BASE_NAME fstpdtscript
+             EXPORT_MACRO_NAME fstpdtscript_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstpdtscript_Export.h
+             STATIC_DEFINE fstpdtscript_BUILT_AS_STATIC
+)
+target_compile_definitions(fstpdtscript PRIVATE fstpdtscript_EXPORTS)
+target_include_directories(fstpdtscript PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+  endif()
+  set_target_properties(fstpdtscript PROPERTIES 
+    SOVERSION "${SOVERSION}"
+  )
+
+  install(TARGETS fstpdtscript
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  )
+endif(HAVE_SCRIPT)
+
+if(HAVE_BIN)
+  function (add_executable2 _name)
+      add_executable(${ARGV})
+      if (TARGET ${_name})
+          target_link_libraries(${_name} fstpdtscript fstscript fst ${CMAKE_DL_LIBS})
+          
+      endif()
+      install(TARGETS ${_name} RUNTIME DESTINATION bin)
+  endfunction()
+
+  add_executable2(pdtcompose  pdtcompose.cc pdtcompose-main.cc)
+  add_executable2(pdtexpand  pdtexpand.cc pdtexpand-main.cc)
+  add_executable2(pdtinfo  pdtinfo.cc pdtinfo-main.cc)
+  add_executable2(pdtreplace  pdtreplace.cc pdtreplace-main.cc)
+  add_executable2(pdtreverse  pdtreverse.cc pdtreverse-main.cc)
+  add_executable2(pdtshortestpath  pdtshortestpath.cc pdtshortestpath-main.cc)
+endif(HAVE_BIN)

--- a/src/extensions/python/CMakeLists.txt
+++ b/src/extensions/python/CMakeLists.txt
@@ -1,0 +1,22 @@
+
+add_library(pywrapfst
+    pywrapfst.cpp
+)
+
+target_link_libraries(pywrapfst
+    fst
+    fstfarscript
+    fstfar
+    fstscript
+)
+
+set_target_properties(pywrapfst PROPERTIES
+  SOVERSION "${SOVERSION}"
+  FOLDER python
+)
+
+install(TARGETS pywrapfst 
+	LIBRARY DESTINATION lib
+	ARCHIVE DESTINATION lib
+	RUNTIME DESTINATION lib
+)

--- a/src/extensions/special/CMakeLists.txt
+++ b/src/extensions/special/CMakeLists.txt
@@ -1,0 +1,47 @@
+
+
+add_library(fstspecial
+  phi-fst.cc
+  rho-fst.cc
+  sigma-fst.cc
+)
+GENERATE_EXPORT_HEADER( fstspecial
+             BASE_NAME fstspecial
+             EXPORT_MACRO_NAME fstspecial_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstspecial_Export.h
+             STATIC_DEFINE fstspecial_BUILT_AS_STATIC
+)
+target_compile_definitions(fstspecial PRIVATE fstspecial_EXPORTS)
+target_include_directories(fstspecial PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+
+set_target_properties(fstspecial PROPERTIES
+  SOVERSION "${SOVERSION}"
+)
+target_link_libraries(fstspecial
+  fst
+)
+
+if(HAVE_BIN)
+  add_executable(fstspecialconvert
+    ../../bin/fstconvert.cc 
+    ../../bin/fstconvert-main.cc
+  )
+
+  set_target_properties(fstspecialconvert PROPERTIES 
+    OUTPUT_NAME fstspecialconvert
+  )
+  target_link_libraries(fstspecialconvert
+  fstspecial
+    fstscript
+    fst
+    ${CMAKE_DL_LIBS}
+  )
+endif(HAVE_BIN)
+
+
+install(TARGETS fstspecial fstspecialconvert
+LIBRARY DESTINATION lib
+ARCHIVE DESTINATION lib
+RUNTIME DESTINATION bin
+)

--- a/src/include/fst/cache.h
+++ b/src/include/fst/cache.h
@@ -41,13 +41,13 @@
 #include <unordered_map>
 #include <functional>
 
-DECLARE_bool(fst_default_cache_gc);
-DECLARE_int64(fst_default_cache_gc_limit);
+DECLARE_export_bool(fst_default_cache_gc, fst_EXPORT);
+DECLARE_export_int64(fst_default_cache_gc_limit, fst_EXPORT);
 
 namespace fst {
 
 // Options for controlling caching behavior; higher level than CacheImplOptions.
-struct CacheOptions {
+struct fst_EXPORT CacheOptions {
   bool gc;          // Enables GC.
   size_t gc_limit;  // Number of bytes allowed before GC.
 

--- a/src/include/fst/compat.h
+++ b/src/include/fst/compat.h
@@ -33,6 +33,13 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <fst/exports/exports.h>
+
+#ifdef _MSC_VER
+#  include <intrin.h>
+#  define __builtin_popcountll __popcnt64
+#  define __builtin_ctzll _tzcnt_u64
+#endif
 
 #if defined(__GNUC__) || defined(__clang__)
 #define OPENFST_DEPRECATED(message) __attribute__((deprecated(message)))
@@ -92,7 +99,7 @@ constexpr To implicit_cast(typename internal::type_identity_t<To> to) {
 }
 
 // Checksums.
-class CheckSummer {
+class fst_EXPORT CheckSummer {
  public:
   CheckSummer();
 
@@ -215,7 +222,7 @@ struct ByAnyChar {
 
 namespace internal {
 
-class StringSplitter {
+class fst_EXPORT StringSplitter {
  public:
   using const_iterator = std::vector<std::string_view>::const_iterator;
   using value_type = std::string_view;
@@ -255,17 +262,17 @@ class StringSplitter {
 // `StrSplit` replacements. Only support splitting on `char` or
 // `ByAnyChar` (notable not on a multi-char string delimiter), and with or
 // without `SkipEmpty`.
-internal::StringSplitter StrSplit(std::string_view full, ByAnyChar delim);
-internal::StringSplitter StrSplit(std::string_view full, char delim);
-internal::StringSplitter StrSplit(std::string_view full, ByAnyChar delim,
+internal::StringSplitter fst_EXPORT StrSplit(std::string_view full, ByAnyChar delim);
+internal::StringSplitter fst_EXPORT StrSplit(std::string_view full, char delim);
+internal::StringSplitter fst_EXPORT StrSplit(std::string_view full, ByAnyChar delim,
                                   SkipEmpty);
-internal::StringSplitter StrSplit(std::string_view full, char delim, SkipEmpty);
+internal::StringSplitter fst_EXPORT StrSplit(std::string_view full, char delim, SkipEmpty);
 
-void StripTrailingAsciiWhitespace(std::string *full);
+void fst_EXPORT StripTrailingAsciiWhitespace(std::string *full);
 
-std::string_view StripTrailingAsciiWhitespace(std::string_view full);
+std::string_view fst_EXPORT StripTrailingAsciiWhitespace(std::string_view full);
 
-class StringOrInt {
+class fst_EXPORT StringOrInt {
  public:
   template <typename T, typename = std::enable_if_t<
                             std::is_convertible_v<T, std::string_view>>>
@@ -283,21 +290,21 @@ class StringOrInt {
 
 // TODO(kbg): Make this work with variadic template, maybe.
 
-inline std::string StrCat(const StringOrInt &s1, const StringOrInt &s2) {
+inline std::string fst_EXPORT StrCat(const StringOrInt &s1, const StringOrInt &s2) {
   return s1.Get() + s2.Get();
 }
 
-inline std::string StrCat(const StringOrInt &s1, const StringOrInt &s2,
+inline std::string fst_EXPORT StrCat(const StringOrInt &s1, const StringOrInt &s2,
                           const StringOrInt &s3) {
   return s1.Get() + StrCat(s2, s3);
 }
 
-inline std::string StrCat(const StringOrInt &s1, const StringOrInt &s2,
+inline std::string fst_EXPORT StrCat(const StringOrInt &s1, const StringOrInt &s2,
                           const StringOrInt &s3, const StringOrInt &s4) {
   return s1.Get() + StrCat(s2, s3, s4);
 }
 
-inline std::string StrCat(const StringOrInt &s1, const StringOrInt &s2,
+inline std::string fst_EXPORT StrCat(const StringOrInt &s1, const StringOrInt &s2,
                           const StringOrInt &s3, const StringOrInt &s4,
                           const StringOrInt &s5) {
   return s1.Get() + StrCat(s2, s3, s4, s5);
@@ -305,13 +312,13 @@ inline std::string StrCat(const StringOrInt &s1, const StringOrInt &s2,
 
 // TODO(agutkin): Remove this once we migrate to C++20, where `starts_with`
 // is available.
-inline bool StartsWith(std::string_view text, std::string_view prefix) {
+inline bool fst_EXPORT StartsWith(std::string_view text, std::string_view prefix) {
   return prefix.empty() ||
          (text.size() >= prefix.size() &&
           memcmp(text.data(), prefix.data(), prefix.size()) == 0);
 }
 
-inline bool ConsumePrefix(std::string_view *s, std::string_view expected) {
+inline bool fst_EXPORT ConsumePrefix(std::string_view *s, std::string_view expected) {
   if (!StartsWith(*s, expected)) return false;
   s->remove_prefix(expected.size());
   return true;

--- a/src/include/fst/encode.h
+++ b/src/include/fst/encode.h
@@ -71,7 +71,7 @@ inline constexpr int32_t kEncodeDeprecatedMagicNumber = 2129983209;
 }  // namespace internal
 
 // Header for the encoder table.
-class EncodeTableHeader {
+class fst_EXPORT EncodeTableHeader {
  public:
   EncodeTableHeader() = default;
 

--- a/src/include/fst/expanded-fst.h
+++ b/src/include/fst/expanded-fst.h
@@ -39,6 +39,11 @@
 #include <fst/properties.h>
 #include <fst/register.h>
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 namespace fst {
 
 // A generic FST plus state count.
@@ -95,6 +100,9 @@ class ExpandedFst : public Fst<A> {
       }
       return Read(strm, FstReadOptions(source));
     } else {
+        #ifdef _WIN32
+          _setmode(_fileno(stdin), _O_BINARY);
+        #endif
       return Read(std::cin, FstReadOptions("standard input"));
     }
   }
@@ -168,6 +176,9 @@ class ImplToExpandedFst : public ImplToFst<Impl, FST> {
       }
       return Impl::Read(strm, FstReadOptions(source));
     } else {
+        #ifdef _WIN32
+          _setmode(_fileno(stdin), _O_BINARY);
+        #endif
       return Impl::Read(std::cin, FstReadOptions("standard input"));
     }
   }

--- a/src/include/fst/exports/exports.h
+++ b/src/include/fst/exports/exports.h
@@ -1,0 +1,34 @@
+
+#ifndef exports_H
+#define exports_H
+
+#ifdef _WIN32
+    #include <fst/exports/fst_Export.h>
+    #include <fst/exports/fstcompact_Export.h>
+    #include <fst/exports/fstcompressscript_Export.h>
+    #include <fst/exports/fstconst_Export.h>
+    #include <fst/exports/fstfarscript_Export.h>
+    #include <fst/exports/fstfar_Export.h>
+    #include <fst/exports/fstlinearscript_Export.h>
+    #include <fst/exports/fstmpdtscript_Export.h>
+    #include <fst/exports/fstngram_Export.h>
+    #include <fst/exports/fstpdtscript_Export.h>
+    #include <fst/exports/fstscript_Export.h>
+    #include <fst/exports/fstspecial_Export.h>
+#else
+
+    #define fst_EXPORT
+    #define fstcompact_EXPORT
+    #define fstcompressscript_EXPORT
+    #define fstconst_EXPORT
+    #define fstconst_EXPORT
+    #define fstfar_EXPORT
+    #define fstfarscript_EXPORT
+    #define fstlinearscript_EXPORT
+    #define fstmpdtscript_EXPORT
+    #define fstngram_EXPORT
+    #define fstpdtscript_EXPORT
+    #define fstscript_EXPORT
+    #define fstspecial_EXPORT
+#endif // _WIN32
+#endif

--- a/src/include/fst/exports/fst_Export.h
+++ b/src/include/fst/exports/fst_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fst_EXPORT_H
+#define fst_EXPORT_H
+
+#ifdef fst_BUILT_AS_STATIC
+#  define fst_EXPORT
+#  define FST_NO_EXPORT
+#else
+#  ifndef fst_EXPORT
+#    ifdef fst_EXPORTS
+        /* We are building this library */
+#      define fst_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fst_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FST_NO_EXPORT
+#    define FST_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FST_DEPRECATED
+#  define FST_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FST_DEPRECATED_EXPORT
+#  define FST_DEPRECATED_EXPORT fst_EXPORT FST_DEPRECATED
+#endif
+
+#ifndef FST_DEPRECATED_NO_EXPORT
+#  define FST_DEPRECATED_NO_EXPORT FST_NO_EXPORT FST_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FST_NO_DEPRECATED
+#    define FST_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fst_EXPORT_H */

--- a/src/include/fst/exports/fstcompact_Export.h
+++ b/src/include/fst/exports/fstcompact_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstcompact_EXPORT_H
+#define fstcompact_EXPORT_H
+
+#ifdef fstcompact_BUILT_AS_STATIC
+#  define fstcompact_EXPORT
+#  define FSTCOMPACT_NO_EXPORT
+#else
+#  ifndef fstcompact_EXPORT
+#    ifdef fstcompact_EXPORTS
+        /* We are building this library */
+#      define fstcompact_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstcompact_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTCOMPACT_NO_EXPORT
+#    define FSTCOMPACT_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTCOMPACT_DEPRECATED
+#  define FSTCOMPACT_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTCOMPACT_DEPRECATED_EXPORT
+#  define FSTCOMPACT_DEPRECATED_EXPORT fstcompact_EXPORT FSTCOMPACT_DEPRECATED
+#endif
+
+#ifndef FSTCOMPACT_DEPRECATED_NO_EXPORT
+#  define FSTCOMPACT_DEPRECATED_NO_EXPORT FSTCOMPACT_NO_EXPORT FSTCOMPACT_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTCOMPACT_NO_DEPRECATED
+#    define FSTCOMPACT_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstcompact_EXPORT_H */

--- a/src/include/fst/exports/fstcompressscript_Export.h
+++ b/src/include/fst/exports/fstcompressscript_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstcompressscript_EXPORT_H
+#define fstcompressscript_EXPORT_H
+
+#ifdef fstcompressscript_BUILT_AS_STATIC
+#  define fstcompressscript_EXPORT
+#  define FSTCOMPRESSSCRIPT_NO_EXPORT
+#else
+#  ifndef fstcompressscript_EXPORT
+#    ifdef fstcompressscript_EXPORTS
+        /* We are building this library */
+#      define fstcompressscript_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstcompressscript_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTCOMPRESSSCRIPT_NO_EXPORT
+#    define FSTCOMPRESSSCRIPT_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTCOMPRESSSCRIPT_DEPRECATED
+#  define FSTCOMPRESSSCRIPT_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTCOMPRESSSCRIPT_DEPRECATED_EXPORT
+#  define FSTCOMPRESSSCRIPT_DEPRECATED_EXPORT fstcompressscript_EXPORT FSTCOMPRESSSCRIPT_DEPRECATED
+#endif
+
+#ifndef FSTCOMPRESSSCRIPT_DEPRECATED_NO_EXPORT
+#  define FSTCOMPRESSSCRIPT_DEPRECATED_NO_EXPORT FSTCOMPRESSSCRIPT_NO_EXPORT FSTCOMPRESSSCRIPT_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTCOMPRESSSCRIPT_NO_DEPRECATED
+#    define FSTCOMPRESSSCRIPT_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstcompressscript_EXPORT_H */

--- a/src/include/fst/exports/fstconst_Export.h
+++ b/src/include/fst/exports/fstconst_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstconst_EXPORT_H
+#define fstconst_EXPORT_H
+
+#ifdef fstconst_BUILT_AS_STATIC
+#  define fstconst_EXPORT
+#  define FSTCONST_NO_EXPORT
+#else
+#  ifndef fstconst_EXPORT
+#    ifdef fstconst_EXPORTS
+        /* We are building this library */
+#      define fstconst_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstconst_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTCONST_NO_EXPORT
+#    define FSTCONST_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTCONST_DEPRECATED
+#  define FSTCONST_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTCONST_DEPRECATED_EXPORT
+#  define FSTCONST_DEPRECATED_EXPORT fstconst_EXPORT FSTCONST_DEPRECATED
+#endif
+
+#ifndef FSTCONST_DEPRECATED_NO_EXPORT
+#  define FSTCONST_DEPRECATED_NO_EXPORT FSTCONST_NO_EXPORT FSTCONST_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTCONST_NO_DEPRECATED
+#    define FSTCONST_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstconst_EXPORT_H */

--- a/src/include/fst/exports/fstfar_Export.h
+++ b/src/include/fst/exports/fstfar_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstfar_EXPORT_H
+#define fstfar_EXPORT_H
+
+#ifdef fstfar_BUILT_AS_STATIC
+#  define fstfar_EXPORT
+#  define FSTFAR_NO_EXPORT
+#else
+#  ifndef fstfar_EXPORT
+#    ifdef fstfar_EXPORTS
+        /* We are building this library */
+#      define fstfar_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstfar_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTFAR_NO_EXPORT
+#    define FSTFAR_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTFAR_DEPRECATED
+#  define FSTFAR_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTFAR_DEPRECATED_EXPORT
+#  define FSTFAR_DEPRECATED_EXPORT fstfar_EXPORT FSTFAR_DEPRECATED
+#endif
+
+#ifndef FSTFAR_DEPRECATED_NO_EXPORT
+#  define FSTFAR_DEPRECATED_NO_EXPORT FSTFAR_NO_EXPORT FSTFAR_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTFAR_NO_DEPRECATED
+#    define FSTFAR_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstfar_EXPORT_H */

--- a/src/include/fst/exports/fstfarscript_Export.h
+++ b/src/include/fst/exports/fstfarscript_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstfarscript_EXPORT_H
+#define fstfarscript_EXPORT_H
+
+#ifdef fstfar_BUILT_AS_STATIC
+#  define fstfarscript_EXPORT
+#  define FSTFARSCRIPT_NO_EXPORT
+#else
+#  ifndef fstfarscript_EXPORT
+#    ifdef fstfarscript_EXPORTS
+        /* We are building this library */
+#      define fstfarscript_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstfarscript_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTFARSCRIPT_NO_EXPORT
+#    define FSTFARSCRIPT_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTFARSCRIPT_DEPRECATED
+#  define FSTFARSCRIPT_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTFARSCRIPT_DEPRECATED_EXPORT
+#  define FSTFARSCRIPT_DEPRECATED_EXPORT fstfarscript_EXPORT FSTFARSCRIPT_DEPRECATED
+#endif
+
+#ifndef FSTFARSCRIPT_DEPRECATED_NO_EXPORT
+#  define FSTFARSCRIPT_DEPRECATED_NO_EXPORT FSTFARSCRIPT_NO_EXPORT FSTFARSCRIPT_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTFARSCRIPT_NO_DEPRECATED
+#    define FSTFARSCRIPT_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstfarscript_EXPORT_H */

--- a/src/include/fst/exports/fstlinearscript_Export.h
+++ b/src/include/fst/exports/fstlinearscript_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstlinearscript_EXPORT_H
+#define fstlinearscript_EXPORT_H
+
+#ifdef fstlinearscript_BUILT_AS_STATIC
+#  define fstlinearscript_EXPORT
+#  define FSTLINEARSCRIPT_NO_EXPORT
+#else
+#  ifndef fstlinearscript_EXPORT
+#    ifdef fstlinearscript_EXPORTS
+        /* We are building this library */
+#      define fstlinearscript_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstlinearscript_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTLINEARSCRIPT_NO_EXPORT
+#    define FSTLINEARSCRIPT_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTLINEARSCRIPT_DEPRECATED
+#  define FSTLINEARSCRIPT_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTLINEARSCRIPT_DEPRECATED_EXPORT
+#  define FSTLINEARSCRIPT_DEPRECATED_EXPORT fstlinearscript_EXPORT FSTLINEARSCRIPT_DEPRECATED
+#endif
+
+#ifndef FSTLINEARSCRIPT_DEPRECATED_NO_EXPORT
+#  define FSTLINEARSCRIPT_DEPRECATED_NO_EXPORT FSTLINEARSCRIPT_NO_EXPORT FSTLINEARSCRIPT_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTLINEARSCRIPT_NO_DEPRECATED
+#    define FSTLINEARSCRIPT_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstlinearscript_EXPORT_H */

--- a/src/include/fst/exports/fstmpdtscript_Export.h
+++ b/src/include/fst/exports/fstmpdtscript_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstmpdtscript_EXPORT_H
+#define fstmpdtscript_EXPORT_H
+
+#ifdef fstmpdtscript_BUILT_AS_STATIC
+#  define fstmpdtscript_EXPORT
+#  define FSTMPDTSCRIPT_NO_EXPORT
+#else
+#  ifndef fstmpdtscript_EXPORT
+#    ifdef fstmpdtscript_EXPORTS
+        /* We are building this library */
+#      define fstmpdtscript_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstmpdtscript_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTMPDTSCRIPT_NO_EXPORT
+#    define FSTMPDTSCRIPT_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTMPDTSCRIPT_DEPRECATED
+#  define FSTMPDTSCRIPT_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTMPDTSCRIPT_DEPRECATED_EXPORT
+#  define FSTMPDTSCRIPT_DEPRECATED_EXPORT fstmpdtscript_EXPORT FSTMPDTSCRIPT_DEPRECATED
+#endif
+
+#ifndef FSTMPDTSCRIPT_DEPRECATED_NO_EXPORT
+#  define FSTMPDTSCRIPT_DEPRECATED_NO_EXPORT FSTMPDTSCRIPT_NO_EXPORT FSTMPDTSCRIPT_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTMPDTSCRIPT_NO_DEPRECATED
+#    define FSTMPDTSCRIPT_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstmpdtscript_EXPORT_H */

--- a/src/include/fst/exports/fstngram_Export.h
+++ b/src/include/fst/exports/fstngram_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstngram_EXPORT_H
+#define fstngram_EXPORT_H
+
+#ifdef fstngram_BUILT_AS_STATIC
+#  define fstngram_EXPORT
+#  define FSTNGRAM_NO_EXPORT
+#else
+#  ifndef fstngram_EXPORT
+#    ifdef fstngram_EXPORTS
+        /* We are building this library */
+#      define fstngram_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstngram_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTNGRAM_NO_EXPORT
+#    define FSTNGRAM_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTNGRAM_DEPRECATED
+#  define FSTNGRAM_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTNGRAM_DEPRECATED_EXPORT
+#  define FSTNGRAM_DEPRECATED_EXPORT fstngram_EXPORT FSTNGRAM_DEPRECATED
+#endif
+
+#ifndef FSTNGRAM_DEPRECATED_NO_EXPORT
+#  define FSTNGRAM_DEPRECATED_NO_EXPORT FSTNGRAM_NO_EXPORT FSTNGRAM_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTNGRAM_NO_DEPRECATED
+#    define FSTNGRAM_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstngram_EXPORT_H */

--- a/src/include/fst/exports/fstpdtscript_Export.h
+++ b/src/include/fst/exports/fstpdtscript_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstpdtscript_EXPORT_H
+#define fstpdtscript_EXPORT_H
+
+#ifdef fstpdtscript_BUILT_AS_STATIC
+#  define fstpdtscript_EXPORT
+#  define FSTPDTSCRIPT_NO_EXPORT
+#else
+#  ifndef fstpdtscript_EXPORT
+#    ifdef fstpdtscript_EXPORTS
+        /* We are building this library */
+#      define fstpdtscript_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstpdtscript_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTPDTSCRIPT_NO_EXPORT
+#    define FSTPDTSCRIPT_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTPDTSCRIPT_DEPRECATED
+#  define FSTPDTSCRIPT_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTPDTSCRIPT_DEPRECATED_EXPORT
+#  define FSTPDTSCRIPT_DEPRECATED_EXPORT fstpdtscript_EXPORT FSTPDTSCRIPT_DEPRECATED
+#endif
+
+#ifndef FSTPDTSCRIPT_DEPRECATED_NO_EXPORT
+#  define FSTPDTSCRIPT_DEPRECATED_NO_EXPORT FSTPDTSCRIPT_NO_EXPORT FSTPDTSCRIPT_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTPDTSCRIPT_NO_DEPRECATED
+#    define FSTPDTSCRIPT_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstpdtscript_EXPORT_H */

--- a/src/include/fst/exports/fstscript_Export.h
+++ b/src/include/fst/exports/fstscript_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstscript_EXPORT_H
+#define fstscript_EXPORT_H
+
+#ifdef fstscript_BUILT_AS_STATIC
+#  define fstscript_EXPORT
+#  define FSTSCRIPT_NO_EXPORT
+#else
+#  ifndef fstscript_EXPORT
+#    ifdef fstscript_EXPORTS
+        /* We are building this library */
+#      define fstscript_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstscript_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTSCRIPT_NO_EXPORT
+#    define FSTSCRIPT_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTSCRIPT_DEPRECATED
+#  define FSTSCRIPT_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTSCRIPT_DEPRECATED_EXPORT
+#  define FSTSCRIPT_DEPRECATED_EXPORT fstscript_EXPORT FSTSCRIPT_DEPRECATED
+#endif
+
+#ifndef FSTSCRIPT_DEPRECATED_NO_EXPORT
+#  define FSTSCRIPT_DEPRECATED_NO_EXPORT FSTSCRIPT_NO_EXPORT FSTSCRIPT_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTSCRIPT_NO_DEPRECATED
+#    define FSTSCRIPT_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstscript_EXPORT_H */

--- a/src/include/fst/exports/fstspecial_Export.h
+++ b/src/include/fst/exports/fstspecial_Export.h
@@ -1,0 +1,42 @@
+
+#ifndef fstspecial_EXPORT_H
+#define fstspecial_EXPORT_H
+
+#ifdef fstspecial_BUILT_AS_STATIC
+#  define fstspecial_EXPORT
+#  define FSTSPECIAL_NO_EXPORT
+#else
+#  ifndef fstspecial_EXPORT
+#    ifdef fstspecial_EXPORTS
+        /* We are building this library */
+#      define fstspecial_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define fstspecial_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef FSTSPECIAL_NO_EXPORT
+#    define FSTSPECIAL_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef FSTSPECIAL_DEPRECATED
+#  define FSTSPECIAL_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef FSTSPECIAL_DEPRECATED_EXPORT
+#  define FSTSPECIAL_DEPRECATED_EXPORT fstspecial_EXPORT FSTSPECIAL_DEPRECATED
+#endif
+
+#ifndef FSTSPECIAL_DEPRECATED_NO_EXPORT
+#  define FSTSPECIAL_DEPRECATED_NO_EXPORT FSTSPECIAL_NO_EXPORT FSTSPECIAL_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef FSTSPECIAL_NO_DEPRECATED
+#    define FSTSPECIAL_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* fstspecial_EXPORT_H */

--- a/src/include/fst/extensions/compress/compress.h
+++ b/src/include/fst/extensions/compress/compress.h
@@ -52,6 +52,11 @@
 #include <fst/visit.h>
 #include <string_view>
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 namespace fst {
 
 // Identifies stream data as a vanilla compressed FST.
@@ -791,6 +796,12 @@ template <class Arc>
       return false;
     }
   }
+  
+  #ifdef _WIN32
+  if (!fstrm.is_open()) {
+      _setmode(_fileno(stdin), _O_BINARY);
+  }
+  #endif
   std::istream &istrm = fstrm.is_open() ? fstrm : std::cin;
   if (!Decompress(istrm, source.empty() ? "standard input" : source, fst)) {
     return false;

--- a/src/include/fst/extensions/compress/compressscript.h
+++ b/src/include/fst/extensions/compress/compressscript.h
@@ -26,6 +26,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -41,7 +42,7 @@ void Compress(CompressArgs *args) {
   args->retval = Compress(fst, source);
 }
 
-bool Compress(const FstClass &fst, const std::string &source);
+bool fstcompressscript_EXPORT Compress(const FstClass &fst, const std::string &source);
 
 using DecompressInnerArgs = std::tuple<const std::string &, MutableFstClass *>;
 
@@ -54,7 +55,7 @@ void Decompress(DecompressArgs *args) {
   args->retval = Decompress(source, fst);
 }
 
-bool Decompress(const std::string &source, MutableFstClass *fst);
+bool fstcompressscript_EXPORT Decompress(const std::string &source, MutableFstClass *fst);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/extensions/far/create.h
+++ b/src/include/fst/extensions/far/create.h
@@ -20,7 +20,9 @@
 #ifndef FST_EXTENSIONS_FAR_CREATE_H_
 #define FST_EXTENSIONS_FAR_CREATE_H_
 
+#ifndef _WIN32
 #include <libgen.h>
+#endif
 
 #include <cstddef>
 #include <cstdint>

--- a/src/include/fst/extensions/far/far-class.h
+++ b/src/include/fst/extensions/far/far-class.h
@@ -32,6 +32,7 @@
 #include <fst/script/fst-class.h>
 #include <fst/script/fstscript.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -40,7 +41,7 @@ namespace script {
 
 // Virtual interface implemented by each concrete FarReaderImpl<A>.
 // See the FarReader interface in far.h for the exact semantics.
-class FarReaderImplBase {
+class fstfarscript_EXPORT FarReaderImplBase {
  public:
   virtual const std::string &ArcType() const = 0;
   virtual bool Done() const = 0;
@@ -94,7 +95,7 @@ class FarReaderClassImpl : public FarReaderImplBase {
   mutable std::unique_ptr<FstClass> fstc_;
 };
 
-class FarReaderClass;
+class fstfarscript_EXPORT FarReaderClass;
 
 using OpenFarReaderClassArgs =
     WithReturnValue<std::unique_ptr<FarReaderClass>,
@@ -175,7 +176,7 @@ void OpenFarReaderClass(OpenFarReaderClassArgs *args) {
 // FarWriter API.
 
 // Virtual interface implemented by each concrete FarWriterImpl<A>.
-class FarWriterImplBase {
+class fstfarscript_EXPORT FarWriterImplBase {
  public:
   // Unlike the lower-level library, this returns a boolean to signal failure
   // due to non-conformant arc types.
@@ -218,7 +219,7 @@ class FarWriterClassImpl : public FarWriterImplBase {
   std::unique_ptr<FarWriter<Arc>> writer_;
 };
 
-class FarWriterClass;
+class fstfarscript_EXPORT FarWriterClass;
 
 using CreateFarWriterClassInnerArgs = std::pair<const std::string &, FarType>;
 

--- a/src/include/fst/extensions/far/farscript.h
+++ b/src/include/fst/extensions/far/farscript.h
@@ -45,6 +45,7 @@
 #include <fst/script/encodemapper-class.h>
 #include <fst/script/script-impl.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -52,7 +53,7 @@ namespace script {
 // Note: it is safe to pass these strings as references because this struct is
 // only used to pass them deeper in the call graph. Be sure you understand why
 // this is so before using this struct for anything else!
-struct FarCompileStringsArgs {
+struct fstfarscript_EXPORT FarCompileStringsArgs {
   const std::vector<std::string> &sources;
   FarWriterClass &writer;
   std::string_view fst_type;
@@ -76,7 +77,7 @@ void CompileStrings(FarCompileStringsArgs *args) {
       args->initial_symbols, args->key_prefix, args->key_suffix);
 }
 
-void CompileStrings(const std::vector<std::string> &sources,
+void fstfarscript_EXPORT CompileStrings(const std::vector<std::string> &sources,
                     FarWriterClass &writer, std::string_view fst_type,
                     int32_t generate_keys, FarEntryType fet, TokenType tt,
                     const std::string &symbols_source,
@@ -94,13 +95,13 @@ void Convert(FarConvertArgs *args) {
   ::fst::Convert<Arc>(reader, writer, std::get<2>(*args));
 }
 
-void Convert(FarReaderClass &reader, FarWriterClass &writer,
+void fstfarscript_EXPORT Convert(FarReaderClass &reader, FarWriterClass &writer,
              std::string_view fst_type);
 
 // Note: it is safe to pass these strings as references because this struct is
 // only used to pass them deeper in the call graph. Be sure you understand why
 // this is so before using this struct for anything else!
-struct FarCreateArgs {
+struct fstfarscript_EXPORT FarCreateArgs {
   const std::vector<std::string> &sources;
   FarWriterClass &writer;
   const int32_t generate_keys;
@@ -115,7 +116,7 @@ void Create(FarCreateArgs *args) {
                          args->key_prefix, args->key_suffix);
 }
 
-void Create(const std::vector<std::string> &sources, FarWriterClass &writer,
+void fstfarscript_EXPORT Create(const std::vector<std::string> &sources, FarWriterClass &writer,
             int32_t generate_keys, const std::string &key_prefix,
             const std::string &key_suffix);
 
@@ -130,7 +131,7 @@ void Decode(FarDecodeArgs *args) {
   Decode(reader, writer, mapper);
 }
 
-void Decode(FarReaderClass &reader, FarWriterClass &writer,
+void fstfarscript_EXPORT Decode(FarReaderClass &reader, FarWriterClass &writer,
             const EncodeMapperClass &encoder);
 
 using FarEncodeArgs =
@@ -144,7 +145,7 @@ void Encode(FarEncodeArgs *args) {
   Encode(reader, writer, mapper);
 }
 
-void Encode(FarReaderClass &reader, FarWriterClass &writer,
+void fstfarscript_EXPORT Encode(FarReaderClass &reader, FarWriterClass &writer,
             EncodeMapperClass *encoder);
 
 using FarEqualInnerArgs = std::tuple<FarReaderClass &, FarReaderClass &, float,
@@ -161,7 +162,7 @@ void Equal(FarEqualArgs *args) {
                             std::get<3>(args->args), std::get<4>(args->args));
 }
 
-bool Equal(FarReaderClass &reader1, FarReaderClass &reader2,
+bool fstfarscript_EXPORT Equal(FarReaderClass &reader1, FarReaderClass &reader2,
            float delta = kDelta, std::string_view begin_key = "",
            std::string_view end_key = "");
 
@@ -178,7 +179,7 @@ void Extract(FarExtractArgs *args) {
                           std::get<5>(*args), std::get<6>(*args));
 }
 
-void Extract(FarReaderClass &reader, int32_t generate_sources,
+void fstfarscript_EXPORT Extract(FarReaderClass &reader, int32_t generate_sources,
              const std::string &keys, const std::string &key_separator,
              const std::string &range_delimiter,
              const std::string &source_prefix,
@@ -194,7 +195,7 @@ void Info(FarInfoArgs *args) {
                        std::get<2>(*args), std::get<3>(*args));
 }
 
-void Info(const std::vector<std::string> &sources, const std::string &arc_type,
+void fstfarscript_EXPORT Info(const std::vector<std::string> &sources, const std::string &arc_type,
           const std::string &begin_key, const std::string &end_key,
           const bool list_fsts);
 
@@ -209,7 +210,7 @@ void GetInfo(FarGetInfoArgs *args) {
                           std::get<4>(*args));
 }
 
-void GetInfo(const std::vector<std::string> &sources,
+void fstfarscript_EXPORT GetInfo(const std::vector<std::string> &sources,
              const std::string &arc_type, const std::string &begin_key,
              const std::string &end_key, const bool list_fsts, FarInfoData *);
 
@@ -228,11 +229,11 @@ void Isomorphic(FarIsomorphicArgs *args) {
       std::get<4>(args->args));
 }
 
-bool Isomorphic(FarReaderClass &reader1, FarReaderClass &reader2,
+bool fstfarscript_EXPORT Isomorphic(FarReaderClass &reader1, FarReaderClass &reader2,
                 float delta = kDelta, std::string_view begin_key = "",
                 std::string_view end_key = "");
 
-struct FarPrintStringsArgs {
+struct fstfarscript_EXPORT FarPrintStringsArgs {
   FarReaderClass &reader;
   const FarEntryType entry_type;
   const TokenType token_type;
@@ -257,7 +258,7 @@ void PrintStrings(FarPrintStringsArgs *args) {
                                args->source_prefix, args->source_suffix);
 }
 
-void PrintStrings(FarReaderClass &reader, const FarEntryType entry_type,
+void fstfarscript_EXPORT PrintStrings(FarReaderClass &reader, const FarEntryType entry_type,
                   const TokenType token_type, const std::string &begin_key,
                   const std::string &end_key, const bool print_key,
                   const bool print_weight, const std::string &symbols_source,

--- a/src/include/fst/extensions/far/getters.h
+++ b/src/include/fst/extensions/far/getters.h
@@ -27,19 +27,20 @@
 #include <fst/extensions/far/far.h>
 #include <fst/string.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
-bool GetFarType(std::string_view str, FarType *far_type);
+bool fstfarscript_EXPORT GetFarType(std::string_view str, FarType *far_type);
 
-bool GetFarEntryType(std::string_view str, FarEntryType *entry_type);
+bool fstfarscript_EXPORT GetFarEntryType(std::string_view str, FarEntryType *entry_type);
 
-void ExpandArgs(int argc, char **argv, int *argcp, char ***argvp);
+void fstfarscript_EXPORT ExpandArgs(int argc, char **argv, int *argcp, char ***argvp);
 
 }  // namespace script
 
-std::string GetFarTypeString(FarType far_type);
+std::string fstfarscript_EXPORT GetFarTypeString(FarType far_type);
 
 }  // namespace fst
 

--- a/src/include/fst/extensions/far/print-strings.h
+++ b/src/include/fst/extensions/far/print-strings.h
@@ -37,8 +37,9 @@
 #include <fst/shortest-distance.h>
 #include <fst/string.h>
 #include <fst/symbol-table.h>
+#include <fst/exports/exports.h>
 
-DECLARE_string(far_field_separator);
+DECLARE_export_string(far_field_separator, fstfarscript_EXPORT);
 
 namespace fst {
 
@@ -101,7 +102,7 @@ void PrintStrings(FarReader<Arc> &reader, FarEntryType entry_type,
       }
       std::string source;
       source = source_prefix + sstrm.str() + source_suffix;
-      std::ofstream ostrm(source);
+      std::ofstream ostrm(source, std::ios_base::out | std::ios_base::binary);
       if (!ostrm) {
         LOG(ERROR) << "PrintStrings: Can't open file: " << source;
         return;

--- a/src/include/fst/extensions/far/script-impl.h
+++ b/src/include/fst/extensions/far/script-impl.h
@@ -24,12 +24,14 @@
 #include <string>
 
 #include <fst/compat.h>
+#include <fst/exports/exports.h>
+
 namespace fst {
 namespace script {
 
-std::string LoadArcTypeFromFar(const std::string &far_source);
+std::string fstfarscript_EXPORT LoadArcTypeFromFar(const std::string &far_source);
 
-std::string LoadArcTypeFromFst(const std::string &fst_source);
+std::string fstfarscript_EXPORT LoadArcTypeFromFst(const std::string &fst_source);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/extensions/far/stlist.h
+++ b/src/include/fst/extensions/far/stlist.h
@@ -41,6 +41,12 @@
 #include <fstream>
 #include <fst/util.h>
 #include <string_view>
+#include <fst/exports/exports.h>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
 
 namespace fst {
 
@@ -124,6 +130,9 @@ class STListReader {
     for (size_t i = 0; i < sources.size(); ++i) {
       if (sources[i].empty()) {
         if (!has_stdin) {
+          #ifdef _WIN32
+            _setmode(_fileno(stdin), _O_BINARY);
+          #endif
           streams_[i] = &std::cin;
           sources_[i] = "stdin";
           has_stdin = true;
@@ -300,7 +309,7 @@ bool ReadSTListHeader(const std::string &source, Header *header) {
   return true;
 }
 
-bool IsSTList(std::string_view source);
+bool fstfar_EXPORT IsSTList(std::string_view source);
 
 }  // namespace fst
 

--- a/src/include/fst/extensions/far/sttable.h
+++ b/src/include/fst/extensions/far/sttable.h
@@ -37,6 +37,7 @@
 #include <fstream>
 #include <fst/util.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 namespace fst {
 
@@ -378,7 +379,7 @@ bool ReadSTTableHeader(const std::string &source, Header *header) {
   return true;
 }
 
-bool IsSTTable(std::string_view source);
+bool fstfar_EXPORT IsSTTable(std::string_view source);
 
 }  // namespace fst
 

--- a/src/include/fst/extensions/linear/linear-fst.h
+++ b/src/include/fst/extensions/linear/linear-fst.h
@@ -50,6 +50,11 @@
 #include <fst/symbol-table.h>
 #include <fst/util.h>
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 namespace fst {
 
 // Forward declaration of the specialized matcher for both
@@ -525,6 +530,9 @@ class LinearTaggerFst : public ImplToFst<internal::LinearTaggerFstImpl<A>> {
       }
       return Read(strm, FstReadOptions(source));
     } else {
+        #ifdef _WIN32
+          _setmode(_fileno(stdin), _O_BINARY);
+        #endif
       return Read(std::cin, FstReadOptions("standard input"));
     }
   }
@@ -545,6 +553,9 @@ class LinearTaggerFst : public ImplToFst<internal::LinearTaggerFstImpl<A>> {
       }
       return Write(strm, FstWriteOptions(source));
     } else {
+      #ifdef _WIN32
+        _setmode(_fileno(stdout), _O_BINARY);
+      #endif
       return Write(std::cout, FstWriteOptions("standard output"));
     }
   }
@@ -976,6 +987,9 @@ class LinearClassifierFst
       }
       return Read(strm, FstReadOptions(source));
     } else {
+        #ifdef _WIN32
+          _setmode(_fileno(stdin), _O_BINARY);
+        #endif
       return Read(std::cin, FstReadOptions("standard input"));
     }
   }
@@ -997,6 +1011,9 @@ class LinearClassifierFst
       }
       return Write(strm, FstWriteOptions(source));
     } else {
+      #ifdef _WIN32
+        _setmode(_fileno(stdout), _O_BINARY);
+      #endif
       return Write(std::cout, FstWriteOptions("standard output"));
     }
   }

--- a/src/include/fst/extensions/linear/linearscript.h
+++ b/src/include/fst/extensions/linear/linearscript.h
@@ -36,12 +36,13 @@
 #include <fst/util.h>
 #include <fst/script/arg-packs.h>
 #include <fst/script/script-impl.h>
+#include <fst/exports/exports.h>
 
-DECLARE_string(delimiter);
-DECLARE_string(empty_symbol);
-DECLARE_string(start_symbol);
-DECLARE_string(end_symbol);
-DECLARE_bool(classifier);
+DECLARE_export_string(delimiter, fstlinearscript_EXPORT);
+DECLARE_export_string(empty_symbol, fstlinearscript_EXPORT);
+DECLARE_export_string(start_symbol, fstlinearscript_EXPORT);
+DECLARE_export_string(end_symbol, fstlinearscript_EXPORT);
+DECLARE_export_bool(classifier, fstlinearscript_EXPORT);
 
 namespace fst {
 namespace script {
@@ -51,9 +52,9 @@ using LinearCompileArgs =
                char **, int, const std::string &, const std::string &,
                const std::string &, const std::string &>;
 
-bool ValidateDelimiter();
+bool fstlinearscript_EXPORT ValidateDelimiter();
 
-bool ValidateEmptySymbol();
+bool fstlinearscript_EXPORT ValidateEmptySymbol();
 
 // Returns the proper label given the symbol. For symbols other than
 // `FST_FLAGS_start_symbol` or `FST_FLAGS_end_symbol`, looks up the symbol
@@ -130,7 +131,7 @@ bool GetModelRecord(const std::string &model, std::istream &strm,
 template <class Arc>
 void AddVocab(const std::string &vocab, SymbolTable *isyms, SymbolTable *fsyms,
               SymbolTable *osyms, LinearFstDataBuilder<Arc> *builder) {
-  std::ifstream in(vocab);
+  std::ifstream in(vocab, std::ios_base::in | std::ios_base::binary);
   if (!in) LOG(FATAL) << "Can't open file: " << vocab;
   size_t num_line = 0, num_added = 0;
   std::vector<std::string> fields;
@@ -156,7 +157,7 @@ template <class Arc>
 void AddVocab(const std::string &vocab, SymbolTable *isyms, SymbolTable *fsyms,
               SymbolTable *osyms,
               LinearClassifierFstDataBuilder<Arc> *builder) {
-  std::ifstream in(vocab);
+  std::ifstream in(vocab, std::ios_base::in | std::ios_base::binary);
   if (!in) LOG(FATAL) << "Can't open file: " << vocab;
   size_t num_line = 0, num_added = 0;
   std::vector<std::string> fields;
@@ -192,7 +193,7 @@ void AddVocab(const std::string &vocab, SymbolTable *isyms, SymbolTable *fsyms,
 template <class Arc>
 void AddModel(const std::string &model, SymbolTable *fsyms, SymbolTable *osyms,
               LinearFstDataBuilder<Arc> *builder) {
-  std::ifstream in(model);
+  std::ifstream in(model, std::ios_base::in | std::ios_base::binary);
   if (!in) LOG(FATAL) << "Can't open file: " << model;
   std::string line;
   std::getline(in, line);
@@ -246,7 +247,7 @@ void AddModel(const std::string &model, SymbolTable *fsyms, SymbolTable *osyms,
 template <class Arc>
 void AddModel(const std::string &model, SymbolTable *fsyms, SymbolTable *osyms,
               LinearClassifierFstDataBuilder<Arc> *builder) {
-  std::ifstream in(model);
+  std::ifstream in(model, std::ios_base::in | std::ios_base::binary);
   if (!in) LOG(FATAL) << "Can't open file: " << model;
   std::string line;
   std::getline(in, line);
@@ -295,8 +296,8 @@ void AddModel(const std::string &model, SymbolTable *fsyms, SymbolTable *osyms,
           << num_line << " lines.";
 }
 
-void SplitByWhitespace(const std::string &str, std::vector<std::string> *out);
-int ScanNumClasses(char **models, int models_length);
+void fstlinearscript_EXPORT SplitByWhitespace(const std::string &str, std::vector<std::string> *out);
+int fstlinearscript_EXPORT ScanNumClasses(char **models, int models_length);
 
 template <class Arc>
 void LinearCompileTpl(LinearCompileArgs *args) {
@@ -348,7 +349,7 @@ void LinearCompileTpl(LinearCompileArgs *args) {
   if (!save_osymbols.empty()) osyms.WriteText(save_osymbols);
 }
 
-void LinearCompile(const std::string &arc_type,
+void fstlinearscript_EXPORT LinearCompile(const std::string &arc_type,
                    const std::string &epsilon_symbol,
                    const std::string &unknown_symbol, const std::string &vocab,
                    char **models, int models_len, const std::string &out,

--- a/src/include/fst/extensions/mpdt/mpdt.h
+++ b/src/include/fst/extensions/mpdt/mpdt.h
@@ -39,10 +39,11 @@
 #include <fst/util.h>
 #include <unordered_map>
 #include <optional>
+#include <fst/exports/exports.h>
 
 namespace fst {
 
-enum class MPdtType : uint8_t {
+enum class fstmpdtscript_EXPORT MPdtType : uint8_t {
   READ_RESTRICT,   // Can only read from first empty stack
   WRITE_RESTRICT,  // Can only write to first empty stack
   NO_RESTRICT,     // No read-write restrictions

--- a/src/include/fst/extensions/mpdt/mpdtscript.h
+++ b/src/include/fst/extensions/mpdt/mpdtscript.h
@@ -40,6 +40,7 @@
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
 #include <fst/script/shortest-path.h>
+#include <fst/exports/exports.h>
 // FstClassPair, and to detect
 // any collisions.
 
@@ -74,7 +75,7 @@ void Compose(MPdtComposeArgs *args) {
   }
 }
 
-void Compose(const FstClass &ifst1, const FstClass &ifst2,
+void fstmpdtscript_EXPORT Compose(const FstClass &ifst1, const FstClass &ifst2,
              const std::vector<std::pair<int64_t, int64_t>> &parens,
              const std::vector<int64_t> &assignments, MutableFstClass *ofst,
              const MPdtComposeOptions &copts, bool left_pdt);
@@ -103,7 +104,7 @@ void Expand(MPdtExpandArgs *args) {
                            std::get<4>(*args).keep_parentheses));
 }
 
-void Expand(const FstClass &ifst,
+void fstmpdtscript_EXPORT Expand(const FstClass &ifst,
             const std::vector<std::pair<int64_t, int64_t>> &parens,
             const std::vector<int64_t> &assignments, MutableFstClass *ofst,
             const MPdtExpandOptions &opts);
@@ -134,7 +135,7 @@ void Reverse(MPdtReverseArgs *args) {
             std::get<2>(*args)->begin());
 }
 
-void Reverse(const FstClass &ifst,
+void fstmpdtscript_EXPORT Reverse(const FstClass &ifst,
              const std::vector<std::pair<int64_t, int64_t>> &parens,
              std::vector<int64_t> *assignments, MutableFstClass *ofst);
 
@@ -161,7 +162,7 @@ void Info(MPdtInfoArgs *args) {
   mpdtinfo.Print();
 }
 
-void Info(const FstClass &ifst,
+void fstmpdtscript_EXPORT Info(const FstClass &ifst,
           const std::vector<std::pair<int64_t, int64_t>> &parens,
           const std::vector<int64_t> &assignments);
 

--- a/src/include/fst/extensions/mpdt/read_write_utils.h
+++ b/src/include/fst/extensions/mpdt/read_write_utils.h
@@ -39,7 +39,7 @@ template <typename Label>
 bool ReadLabelTriples(const std::string &source,
                       std::vector<std::pair<Label, Label>> *pairs,
                       std::vector<Label> *assignments) {
-  std::ifstream fstrm(source);
+  std::ifstream fstrm(source, std::ios_base::in | std::ios_base::binary);
   if (!fstrm) {
     LOG(ERROR) << "ReadIntTriples: Can't open file: " << source;
     return false;
@@ -82,7 +82,7 @@ bool WriteLabelTriples(const std::string &source,
     LOG(ERROR) << "WriteLabelTriples: Pairs and assignments of different sizes";
     return false;
   }
-  std::ofstream fstrm(source);
+  std::ofstream fstrm(source, std::ios_base::out | std::ios_base::binary);
   if (!fstrm) {
     LOG(ERROR) << "WriteLabelTriples: Can't open file: " << source;
     return false;

--- a/src/include/fst/extensions/ngram/bitmap-index.h
+++ b/src/include/fst/extensions/ngram/bitmap-index.h
@@ -25,6 +25,7 @@
 
 #include <fst/compat.h>
 #include <fst/log.h>
+#include <fst/exports/exports.h>
 
 // This class is a bitstring storage class with an index that allows
 // seeking to the Nth set or clear bit in time O(Log(N)) (or
@@ -89,7 +90,7 @@
 
 namespace fst {
 
-class BitmapIndex {
+class fstngram_EXPORT BitmapIndex {
  public:
   static size_t StorageSize(size_t num_bits) {
     return ((num_bits + kStorageBlockMask) >> kStorageLogBitSize);

--- a/src/include/fst/extensions/ngram/ngram-fst.h
+++ b/src/include/fst/extensions/ngram/ngram-fst.h
@@ -52,6 +52,11 @@
 #include <fst/util.h>
 #include <fst/vector-fst.h>
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 namespace fst {
 template <class A>
 class NGramFst;
@@ -417,6 +422,9 @@ class NGramFst : public ImplToExpandedFst<internal::NGramFstImpl<A>> {
       }
       return Read(strm, FstReadOptions(source));
     } else {
+        #ifdef _WIN32
+          _setmode(_fileno(stdin), _O_BINARY);
+        #endif
       return Read(std::cin, FstReadOptions("standard input"));
     }
   }

--- a/src/include/fst/extensions/ngram/nthbit.h
+++ b/src/include/fst/extensions/ngram/nthbit.h
@@ -26,6 +26,7 @@
 #endif
 
 #include <fst/log.h>
+#include <fst/compat.h>
 
 #if defined(__BMI2__)  // Intel Bit Manipulation Instruction Set 2
 // PDEP requires BMI2; this is present starting with Haswell.
@@ -83,7 +84,7 @@ extern const uint8_t kSelectInByte[2048];
 // Rank/Select Queries" by Sebastiano Vigna, p. 5, Algorithm 2, with
 // improvements from "Optimized Succinct Data Structures for Massive Data"
 // by Gog & Petri, 2014.
-inline int nth_bit(const uint64_t v, const uint32_t r) {
+inline int fstngram_EXPORT nth_bit(const uint64_t v, const uint32_t r) {
   constexpr uint64_t kOnesStep8 = 0x0101010101010101;
   constexpr uint64_t kMSBsStep8 = 0x80 * kOnesStep8;
 

--- a/src/include/fst/extensions/pdt/getters.h
+++ b/src/include/fst/extensions/pdt/getters.h
@@ -23,13 +23,14 @@
 #include <fst/extensions/pdt/compose.h>
 #include <fst/extensions/pdt/replace.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
-bool GetPdtComposeFilter(std::string_view str, PdtComposeFilter *cf);
+bool fstpdtscript_EXPORT GetPdtComposeFilter(std::string_view str, PdtComposeFilter *cf);
 
-bool GetPdtParserType(std::string_view str, PdtParserType *pt);
+bool fstpdtscript_EXPORT GetPdtParserType(std::string_view str, PdtParserType *pt);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/extensions/pdt/pdtscript.h
+++ b/src/include/fst/extensions/pdt/pdtscript.h
@@ -47,6 +47,7 @@
 #include <fst/script/script-impl.h>
 #include <fst/script/shortest-path.h>
 #include <fst/script/weight-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -75,12 +76,12 @@ void Compose(PdtComposeArgs *args) {
   }
 }
 
-void Compose(const FstClass &ifst1, const FstClass &ifst2,
+void fstpdtscript_EXPORT Compose(const FstClass &ifst1, const FstClass &ifst2,
              const std::vector<std::pair<int64_t, int64_t>> &parens,
              MutableFstClass *ofst, const PdtComposeOptions &opts,
              bool left_pdt);
 
-struct PdtExpandOptions {
+struct fstpdtscript_EXPORT PdtExpandOptions {
   bool connect;
   bool keep_parentheses;
   const WeightClass &weight_threshold;
@@ -112,11 +113,11 @@ void Expand(PdtExpandArgs *args) {
                    .weight_threshold.GetWeight<typename Arc::Weight>())));
 }
 
-void Expand(const FstClass &ifst,
+void fstpdtscript_EXPORT Expand(const FstClass &ifst,
             const std::vector<std::pair<int64_t, int64_t>> &parens,
             MutableFstClass *ofst, const PdtExpandOptions &opts);
 
-void Expand(const FstClass &ifst,
+void fstpdtscript_EXPORT Expand(const FstClass &ifst,
             const std::vector<std::pair<int64_t, int64_t>> &parens,
             MutableFstClass *ofst, bool connect, bool keep_parentheses,
             const WeightClass &weight_threshold);
@@ -149,7 +150,7 @@ void Replace(PdtReplaceArgs *args) {
             std::get<2>(*args)->begin());
 }
 
-void Replace(const std::vector<std::pair<int64_t, const FstClass *>> &pairs,
+void fstpdtscript_EXPORT Replace(const std::vector<std::pair<int64_t, const FstClass *>> &pairs,
              MutableFstClass *ofst,
              std::vector<std::pair<int64_t, int64_t>> *parens, int64_t root,
              PdtParserType parser_type = PdtParserType::LEFT,
@@ -176,13 +177,13 @@ void Reverse(PdtReverseArgs *args) {
   Reverse(fst, typed_parens, ofst);
 }
 
-void Reverse(const FstClass &ifst,
+void fstpdtscript_EXPORT Reverse(const FstClass &ifst,
              const std::vector<std::pair<int64_t, int64_t>> &,
              MutableFstClass *ofst);
 
 // PDT SHORTESTPATH
 
-struct PdtShortestPathOptions {
+struct fstpdtscript_EXPORT PdtShortestPathOptions {
   QueueType queue_type;
   bool keep_parentheses;
   bool path_gc;
@@ -237,7 +238,7 @@ void ShortestPath(PdtShortestPathArgs *args) {
   }
 }
 
-void ShortestPath(
+void fstpdtscript_EXPORT ShortestPath(
     const FstClass &ifst,
     const std::vector<std::pair<int64_t, int64_t>> &parens,
     MutableFstClass *ofst,
@@ -262,7 +263,7 @@ void Info(PdtInfoArgs *args) {
   pdtinfo.Print();
 }
 
-void Info(const FstClass &ifst,
+void fstpdtscript_EXPORT Info(const FstClass &ifst,
           const std::vector<std::pair<int64_t, int64_t>> &parens);
 
 }  // namespace script

--- a/src/include/fst/extensions/special/phi-fst.h
+++ b/src/include/fst/extensions/special/phi-fst.h
@@ -31,10 +31,11 @@
 #include <fst/matcher-fst.h>
 #include <fst/matcher.h>
 #include <fst/util.h>
+#include <fst/exports/exports.h>
 
-DECLARE_int64(phi_fst_phi_label);
-DECLARE_bool(phi_fst_phi_loop);
-DECLARE_string(phi_fst_rewrite_mode);
+DECLARE_export_int64(phi_fst_phi_label,  fstspecial_EXPORT);
+DECLARE_export_bool(phi_fst_phi_loop, fstspecial_EXPORT);
+DECLARE_export_string(phi_fst_rewrite_mode, fstspecial_EXPORT);
 
 namespace fst {
 namespace internal {

--- a/src/include/fst/extensions/special/rho-fst.h
+++ b/src/include/fst/extensions/special/rho-fst.h
@@ -31,9 +31,10 @@
 #include <fst/matcher-fst.h>
 #include <fst/matcher.h>
 #include <fst/util.h>
+#include <fst/exports/exports.h>
 
-DECLARE_int64(rho_fst_rho_label);
-DECLARE_string(rho_fst_rewrite_mode);
+DECLARE_export_int64(rho_fst_rho_label, fstspecial_EXPORT);
+DECLARE_export_string(rho_fst_rewrite_mode, fstspecial_EXPORT);
 
 namespace fst {
 namespace internal {

--- a/src/include/fst/extensions/special/sigma-fst.h
+++ b/src/include/fst/extensions/special/sigma-fst.h
@@ -31,9 +31,10 @@
 #include <fst/matcher-fst.h>
 #include <fst/matcher.h>
 #include <fst/util.h>
+#include <fst/exports/exports.h>
 
-DECLARE_int64(sigma_fst_sigma_label);
-DECLARE_string(sigma_fst_rewrite_mode);
+DECLARE_export_int64(sigma_fst_sigma_label, fstspecial_EXPORT);
+DECLARE_export_string(sigma_fst_rewrite_mode, fstspecial_EXPORT);
 
 namespace fst {
 namespace internal {

--- a/src/include/fst/fst.h
+++ b/src/include/fst/fst.h
@@ -49,14 +49,20 @@
 #include <fst/util.h>
 #include <string_view>
 
-DECLARE_bool(fst_align);
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
+DECLARE_export_bool(fst_align, fst_EXPORT);
+DECLARE_export_bool(fst_verify_properties, fst_EXPORT);
 
 namespace fst {
 
 // Identifies stream data as an FST (and its endianity).
 inline constexpr int32_t kFstMagicNumber = 2125659606;
 
-class FstHeader;
+class fst_EXPORT FstHeader;
 template <class Arc>
 class MatcherBase;
 template <class Arc>
@@ -64,7 +70,7 @@ struct ArcIteratorData;
 template <class Arc>
 struct StateIteratorData;
 
-struct FstReadOptions {
+struct fst_EXPORT FstReadOptions {
   // FileReadMode(s) are advisory, there are many conditions than prevent a
   // file from being mapped, READ mode will be selected in these cases with
   // a warning indicating why it was chosen.
@@ -98,7 +104,7 @@ struct FstReadOptions {
   std::string DebugString() const;
 };
 
-struct FstWriteOptions {
+struct fst_EXPORT FstWriteOptions {
   std::string source;   // Where you're writing to.
   bool write_header;    // Write the header?
   bool write_isymbols;  // Write input symbols?
@@ -285,6 +291,9 @@ class Fst {
       }
       return Read(strm, FstReadOptions(source));
     } else {
+        #ifdef _WIN32
+          _setmode(_fileno(stdin), _O_BINARY);
+        #endif
       return Read(std::cin, FstReadOptions("standard input"));
     }
   }
@@ -343,6 +352,9 @@ class Fst {
       }
       return true;
     } else {
+      #ifdef _WIN32
+        _setmode(_fileno(stdout), _O_BINARY);
+      #endif
       return Write(std::cout, FstWriteOptions("standard output"));
     }
   }

--- a/src/include/fst/log.h
+++ b/src/include/fst/log.h
@@ -31,7 +31,7 @@
 class LogMessage;
 class LogMessage;
 
-DECLARE_int32(v);
+DECLARE_export_int32(v, fst_EXPORT);
 
 class LogMessage {
  public:

--- a/src/include/fst/lookahead-matcher.h
+++ b/src/include/fst/lookahead-matcher.h
@@ -43,8 +43,8 @@
 #include <fst/vector-fst.h>
 #include <string_view>
 
-DECLARE_string(save_relabel_ipairs);
-DECLARE_string(save_relabel_opairs);
+DECLARE_export_string(save_relabel_ipairs, fst_EXPORT);
+DECLARE_export_string(save_relabel_opairs, fst_EXPORT);
 
 namespace fst {
 

--- a/src/include/fst/mapped-file.h
+++ b/src/include/fst/mapped-file.h
@@ -48,7 +48,7 @@ struct MemoryRegion {
 #endif
 };
 
-class MappedFile {
+class fst_EXPORT MappedFile {
  public:
   ~MappedFile();
 

--- a/src/include/fst/mutable-fst.h
+++ b/src/include/fst/mutable-fst.h
@@ -43,6 +43,11 @@
 #include <fst/symbol-table.h>
 #include <string_view>
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 namespace fst {
 
 template <class Arc>
@@ -166,6 +171,9 @@ class MutableFst : public ExpandedFst<A> {
         }
         return Read(strm, FstReadOptions(source));
       } else {
+        #ifdef _WIN32
+          _setmode(_fileno(stdin), _O_BINARY);
+        #endif
         return Read(std::cin, FstReadOptions("standard input"));
       }
     } else {  // Converts to 'convert_type' if not mutable.

--- a/src/include/fst/properties.h
+++ b/src/include/fst/properties.h
@@ -349,46 +349,46 @@ inline uint64_t DeleteAllStatesProperties(uint64_t inprops,
 
 inline uint64_t DeleteArcsProperties(uint64_t inprops);
 
-uint64_t ClosureProperties(uint64_t inprops, bool star, bool delayed = false);
+uint64_t fst_EXPORT ClosureProperties(uint64_t inprops, bool star, bool delayed = false);
 
-uint64_t ComplementProperties(uint64_t inprops);
+uint64_t fst_EXPORT ComplementProperties(uint64_t inprops);
 
-uint64_t ComposeProperties(uint64_t inprops1, uint64_t inprops2);
+uint64_t fst_EXPORT ComposeProperties(uint64_t inprops1, uint64_t inprops2);
 
-uint64_t ConcatProperties(uint64_t inprops1, uint64_t inprops2,
+uint64_t fst_EXPORT ConcatProperties(uint64_t inprops1, uint64_t inprops2,
                           bool delayed = false);
 
-uint64_t DeterminizeProperties(uint64_t inprops, bool has_subsequential_label,
+uint64_t fst_EXPORT DeterminizeProperties(uint64_t inprops, bool has_subsequential_label,
                                bool distinct_psubsequential_labels);
 
-uint64_t FactorWeightProperties(uint64_t inprops);
+uint64_t fst_EXPORT FactorWeightProperties(uint64_t inprops);
 
-uint64_t InvertProperties(uint64_t inprops);
+uint64_t fst_EXPORT InvertProperties(uint64_t inprops);
 
-uint64_t ProjectProperties(uint64_t inprops, bool project_input);
+uint64_t fst_EXPORT ProjectProperties(uint64_t inprops, bool project_input);
 
-uint64_t RandGenProperties(uint64_t inprops, bool weighted);
+uint64_t fst_EXPORT RandGenProperties(uint64_t inprops, bool weighted);
 
-uint64_t RelabelProperties(uint64_t inprops);
+uint64_t fst_EXPORT RelabelProperties(uint64_t inprops);
 
-uint64_t ReplaceProperties(const std::vector<uint64_t> &inprops, size_t root,
+uint64_t fst_EXPORT ReplaceProperties(const std::vector<uint64_t> &inprops, size_t root,
                            bool epsilon_on_call, bool epsilon_on_return,
                            bool out_epsilon_on_call, bool out_epsilon_on_return,
                            bool replace_transducer, bool no_empty_fst,
                            bool all_ilabel_sorted, bool all_olabel_sorted,
                            bool all_negative_or_dense);
 
-uint64_t ReverseProperties(uint64_t inprops, bool has_superinitial);
+uint64_t fst_EXPORT ReverseProperties(uint64_t inprops, bool has_superinitial);
 
-uint64_t ReweightProperties(uint64_t inprops, bool added_start_epsilon);
+uint64_t fst_EXPORT ReweightProperties(uint64_t inprops, bool added_start_epsilon);
 
-uint64_t RmEpsilonProperties(uint64_t inprops, bool delayed = false);
+uint64_t fst_EXPORT RmEpsilonProperties(uint64_t inprops, bool delayed = false);
 
-uint64_t ShortestPathProperties(uint64_t props, bool tree = false);
+uint64_t fst_EXPORT ShortestPathProperties(uint64_t props, bool tree = false);
 
-uint64_t SynchronizeProperties(uint64_t inprops);
+uint64_t fst_EXPORT SynchronizeProperties(uint64_t inprops);
 
-uint64_t UnionProperties(uint64_t inprops1, uint64_t inprops2,
+uint64_t fst_EXPORT UnionProperties(uint64_t inprops1, uint64_t inprops2,
                          bool delayed = false);
 
 // Definitions of inlined functions.
@@ -492,7 +492,7 @@ uint64_t AddArcProperties(uint64_t inprops, typename Arc::StateId s,
 
 namespace internal {
 
-extern const std::string_view PropertyNames[];
+extern const std::string_view fst_EXPORT PropertyNames[];
 
 // For a binary property, the bit is always returned set. For a trinary (i.e.,
 // two-bit) property, both bits are returned set iff either corresponding input

--- a/src/include/fst/register.h
+++ b/src/include/fst/register.h
@@ -75,7 +75,15 @@ class FstRegister : public GenericRegister<std::string, FstRegisterEntry<Arc>,
   std::string ConvertKeyToSoFilename(std::string_view key) const override {
     std::string legal_type(key);
     ConvertToLegalCSymbol(&legal_type);
-    legal_type.append("-fst.so");
+    legal_type.append("-fst");
+    #ifdef _WIN32
+        legal_type.append(".dll");
+    #elif defined __APPLE__
+        legal_type.append(".dylib");
+    #else
+        legal_type.append(".so");
+
+    #endif // _WIN32
     return legal_type;
   }
 };

--- a/src/include/fst/script/arc-class.h
+++ b/src/include/fst/script/arc-class.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 
 #include <fst/script/weight-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -28,7 +29,7 @@ namespace script {
 // A struct representing an arc while ignoring arc type. It is passed as an
 // argument to AddArc.
 
-struct ArcClass {
+struct fstscript_EXPORT ArcClass {
   template <class Arc>
   explicit ArcClass(const Arc &arc)
       : ilabel(arc.ilabel),

--- a/src/include/fst/script/arcfilter-impl.h
+++ b/src/include/fst/script/arcfilter-impl.h
@@ -19,10 +19,11 @@
 #define FST_SCRIPT_ARCFILTER_IMPL_H_
 
 #include <cstdint>
+#include <fst/exports/exports.h>
 
 namespace fst::script {
 
-enum class ArcFilterType : uint8_t {
+enum class fstscript_EXPORT ArcFilterType : uint8_t {
   ANY,
   EPSILON,
   INPUT_EPSILON,

--- a/src/include/fst/script/arciterator-class.h
+++ b/src/include/fst/script/arciterator-class.h
@@ -41,7 +41,7 @@ namespace script {
 // Non-mutable arc iterators.
 
 // Virtual interface implemented by each concrete ArcIteratorImpl<F>.
-class ArcIteratorImplBase {
+class fstscript_EXPORT ArcIteratorImplBase {
  public:
   virtual bool Done() const = 0;
   virtual uint8_t Flags() const = 0;

--- a/src/include/fst/script/arcsort.h
+++ b/src/include/fst/script/arcsort.h
@@ -28,7 +28,7 @@
 namespace fst {
 namespace script {
 
-enum class ArcSortType : uint8_t { ILABEL, OLABEL };
+enum class fstscript_EXPORT ArcSortType : uint8_t { ILABEL, OLABEL };
 
 using FstArcSortArgs = std::pair<MutableFstClass *, ArcSortType>;
 
@@ -49,7 +49,7 @@ void ArcSort(FstArcSortArgs *args) {
   }
 }
 
-void ArcSort(MutableFstClass *ofst, ArcSortType);
+void fstscript_EXPORT ArcSort(MutableFstClass *ofst, ArcSortType);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/closure.h
+++ b/src/include/fst/script/closure.h
@@ -24,6 +24,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/rational.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -36,7 +37,7 @@ void Closure(FstClosureArgs *args) {
   Closure(fst, std::get<1>(*args));
 }
 
-void Closure(MutableFstClass *ofst, ClosureType closure_type);
+void fstscript_EXPORT Closure(MutableFstClass *ofst, ClosureType closure_type);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/compile-impl.h
+++ b/src/include/fst/script/compile-impl.h
@@ -38,8 +38,6 @@
 #include <unordered_map>
 #include <string_view>
 
-DECLARE_string(fst_field_separator);
-
 namespace fst {
 
 // Compile a binary FST from textual input, helper class for fstcompile.cc.

--- a/src/include/fst/script/compile.h
+++ b/src/include/fst/script/compile.h
@@ -31,6 +31,7 @@
 #include <fst/script/arg-packs.h>
 #include <fst/script/compile-impl.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -44,7 +45,7 @@ namespace script {
 // this struct is only used to pass them deeper in the call graph.
 // Be sure you understand why this is so before using this struct
 // for anything else!
-struct FstCompileInnerArgs {
+struct fstscript_EXPORT FstCompileInnerArgs {
   std::istream &istrm;
   const std::string &source;
   const std::string &fst_type;
@@ -84,13 +85,13 @@ void CompileInternal(FstCompileArgs *args) {
   args->retval = fst ? std::make_unique<FstClass>(std::move(fst)) : nullptr;
 }
 
-void Compile(std::istream &istrm, const std::string &source,
+void fstscript_EXPORT Compile(std::istream &istrm, const std::string &source,
              const std::string &dest, const std::string &fst_type,
              const std::string &arc_type, const SymbolTable *isyms,
              const SymbolTable *osyms, const SymbolTable *ssyms, bool accep,
              bool ikeep, bool okeep, bool nkeep);
 
-std::unique_ptr<FstClass> CompileInternal(
+std::unique_ptr<FstClass> fstscript_EXPORT CompileInternal(
     std::istream &istrm, const std::string &source, const std::string &fst_type,
     const std::string &arc_type, const SymbolTable *isyms,
     const SymbolTable *osyms, const SymbolTable *ssyms, bool accep, bool ikeep,

--- a/src/include/fst/script/compose.h
+++ b/src/include/fst/script/compose.h
@@ -24,6 +24,7 @@
 #include <fst/fst.h>
 #include <fst/mutable-fst.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -40,7 +41,7 @@ void Compose(FstComposeArgs *args) {
   Compose(ifst1, ifst2, ofst, opts);
 }
 
-void Compose(const FstClass &ifst1, const FstClass &ifst2,
+void fstscript_EXPORT Compose(const FstClass &ifst1, const FstClass &ifst2,
              MutableFstClass *ofst,
              const ComposeOptions &opts = ComposeOptions());
 

--- a/src/include/fst/script/concat.h
+++ b/src/include/fst/script/concat.h
@@ -25,6 +25,7 @@
 #include <fst/fst.h>
 #include <fst/mutable-fst.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -62,11 +63,11 @@ void Concat(FstConcatArgs3 *args) {
   Concat(typed_fsts1, fst2);
 }
 
-void Concat(MutableFstClass *fst1, const FstClass &fst2);
+void fstscript_EXPORT Concat(MutableFstClass *fst1, const FstClass &fst2);
 
-void Concat(const FstClass &fst1, MutableFstClass *fst2);
+void fstscript_EXPORT Concat(const FstClass &fst1, MutableFstClass *fst2);
 
-void Concat(const std::vector<FstClass *> &fsts1, MutableFstClass *fst2);
+void fstscript_EXPORT Concat(const std::vector<FstClass *> &fsts1, MutableFstClass *fst2);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/connect.h
+++ b/src/include/fst/script/connect.h
@@ -20,6 +20,7 @@
 
 #include <fst/connect.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -29,7 +30,7 @@ void Connect(MutableFstClass *fst) {
   Connect(fst->GetMutableFst<Arc>());
 }
 
-void Connect(MutableFstClass *fst);
+void fstscript_EXPORT Connect(MutableFstClass *fst);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/convert.h
+++ b/src/include/fst/script/convert.h
@@ -26,6 +26,7 @@
 #include <fst/register.h>
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -44,7 +45,7 @@ void Convert(FstConvertArgs *args) {
       result ? std::make_unique<FstClass>(std::move(result)) : nullptr;
 }
 
-std::unique_ptr<FstClass> Convert(const FstClass &fst,
+std::unique_ptr<FstClass> fstscript_EXPORT Convert(const FstClass &fst,
                                   const std::string &new_type);
 
 }  // namespace script

--- a/src/include/fst/script/decode.h
+++ b/src/include/fst/script/decode.h
@@ -25,6 +25,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/script/encodemapper-class.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -38,7 +39,7 @@ void Decode(FstDecodeArgs *args) {
   Decode(fst, mapper);
 }
 
-void Decode(MutableFstClass *fst, const EncodeMapperClass &encoder);
+void fstscript_EXPORT Decode(MutableFstClass *fst, const EncodeMapperClass &encoder);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/determinize.h
+++ b/src/include/fst/script/determinize.h
@@ -26,11 +26,12 @@
 #include <fst/mutable-fst.h>
 #include <fst/script/fst-class.h>
 #include <fst/script/weight-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
-struct DeterminizeOptions {
+struct fstscript_EXPORT DeterminizeOptions {
   const float delta;
   const WeightClass &weight_threshold;
   const int64_t state_threshold;
@@ -68,7 +69,7 @@ void Determinize(FstDeterminizeArgs *args) {
   Determinize(ifst, ofst, detargs);
 }
 
-void Determinize(const FstClass &ifst, MutableFstClass *ofst,
+void fstscript_EXPORT Determinize(const FstClass &ifst, MutableFstClass *ofst,
                  const DeterminizeOptions &opts);
 
 }  // namespace script

--- a/src/include/fst/script/difference.h
+++ b/src/include/fst/script/difference.h
@@ -26,6 +26,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/script/compose.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -42,7 +43,7 @@ void Difference(FstDifferenceArgs *args) {
   Difference(ifst1, ifst2, ofst, opts);
 }
 
-void Difference(const FstClass &ifst1, const FstClass &ifst2,
+void fstscript_EXPORT Difference(const FstClass &ifst1, const FstClass &ifst2,
                 MutableFstClass *ofst,
                 const ComposeOptions &opts = ComposeOptions());
 

--- a/src/include/fst/script/disambiguate.h
+++ b/src/include/fst/script/disambiguate.h
@@ -27,11 +27,12 @@
 #include <fst/mutable-fst.h>
 #include <fst/script/fst-class.h>
 #include <fst/script/weight-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
-struct DisambiguateOptions {
+struct fstscript_EXPORT DisambiguateOptions {
   const float delta;
   const WeightClass &weight_threshold;
   const int64_t state_threshold;
@@ -62,7 +63,7 @@ void Disambiguate(FstDisambiguateArgs *args) {
   Disambiguate(ifst, ofst, disargs);
 }
 
-void Disambiguate(const FstClass &ifst, MutableFstClass *ofst,
+void fstscript_EXPORT Disambiguate(const FstClass &ifst, MutableFstClass *ofst,
                   const DisambiguateOptions &opts);
 
 }  // namespace script

--- a/src/include/fst/script/draw.h
+++ b/src/include/fst/script/draw.h
@@ -25,6 +25,7 @@
 #include <fst/symbol-table.h>
 #include <fst/script/draw-impl.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -32,7 +33,7 @@ namespace script {
 // Note: it is safe to pass these strings as references because this struct is
 // only used to pass them deeper in the call graph. Be sure you understand why
 // this is so before using this struct for anything else!
-struct FstDrawArgs {
+struct fstscript_EXPORT FstDrawArgs {
   const FstClass &fst;
   const SymbolTable *isyms;
   const SymbolTable *osyms;
@@ -64,7 +65,7 @@ void Draw(FstDrawArgs *args) {
   fstdrawer.Draw(args->ostrm, args->dest);
 }
 
-void Draw(const FstClass &fst, const SymbolTable *isyms,
+void fstscript_EXPORT Draw(const FstClass &fst, const SymbolTable *isyms,
           const SymbolTable *osyms, const SymbolTable *ssyms, bool accep,
           const std::string &title, float width, float height, bool portrait,
           bool vertical, float ranksep, float nodesep, int fontsize,

--- a/src/include/fst/script/encode.h
+++ b/src/include/fst/script/encode.h
@@ -25,6 +25,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/script/encodemapper-class.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -38,7 +39,7 @@ void Encode(FstEncodeArgs *args) {
   Encode(fst, mapper);
 }
 
-void Encode(MutableFstClass *fst, EncodeMapperClass *mapper);
+void fstscript_EXPORT Encode(MutableFstClass *fst, EncodeMapperClass *mapper);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/encodemapper-class.h
+++ b/src/include/fst/script/encodemapper-class.h
@@ -33,6 +33,7 @@
 #include <fst/script/arc-class.h>
 #include <fst/script/fst-class.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 // Scripting API support for EncodeMapper.
 
@@ -40,7 +41,7 @@ namespace fst {
 namespace script {
 
 // Virtual interface implemented by each concrete EncodeMapperClassImpl<Arc>.
-class EncodeMapperImplBase {
+class fstscript_EXPORT EncodeMapperImplBase {
  public:
   // Returns an encoded ArcClass.
   virtual ArcClass operator()(const ArcClass &) = 0;
@@ -125,7 +126,7 @@ inline ArcClass EncodeMapperClassImpl<Arc>::operator()(const ArcClass &a) {
   return ArcClass(mapper_(arc));
 }
 
-class EncodeMapperClass {
+class fstscript_EXPORT EncodeMapperClass {
  public:
   EncodeMapperClass() : impl_(nullptr) {}
 
@@ -264,7 +265,15 @@ class EncodeMapperClassIORegister
   std::string ConvertKeyToSoFilename(std::string_view key) const final {
     std::string legal_type(key);
     ConvertToLegalCSymbol(&legal_type);
-    legal_type.append("-arc.so");
+    legal_type.append("-arc");
+    #ifdef _WIN32
+        legal_type.append(".dll");
+    #elif defined __APPLE__
+        legal_type.append(".dylib");
+    #else
+        legal_type.append(".so");
+
+    #endif // _WIN32
     return legal_type;
   }
 };

--- a/src/include/fst/script/epsnormalize.h
+++ b/src/include/fst/script/epsnormalize.h
@@ -24,6 +24,7 @@
 #include <fst/fst.h>
 #include <fst/mutable-fst.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -38,7 +39,7 @@ void EpsNormalize(FstEpsNormalizeArgs *args) {
   EpsNormalize(ifst, ofst, std::get<2>(*args));
 }
 
-void EpsNormalize(const FstClass &ifst, MutableFstClass *ofst,
+void fstscript_EXPORT EpsNormalize(const FstClass &ifst, MutableFstClass *ofst,
                   EpsNormalizeType norm_type = EPS_NORM_INPUT);
 
 }  // namespace script

--- a/src/include/fst/script/equal.h
+++ b/src/include/fst/script/equal.h
@@ -25,6 +25,7 @@
 #include <fst/weight.h>
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -40,7 +41,7 @@ void Equal(FstEqualArgs *args) {
   args->retval = Equal(fst1, fst2, std::get<2>(args->args));
 }
 
-bool Equal(const FstClass &fst1, const FstClass &fst2, float delta = kDelta);
+bool fstscript_EXPORT Equal(const FstClass &fst1, const FstClass &fst2, float delta = kDelta);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/equivalent.h
+++ b/src/include/fst/script/equivalent.h
@@ -25,6 +25,7 @@
 #include <fst/weight.h>
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -42,7 +43,7 @@ void Equivalent(FstEquivalentArgs *args) {
       Equivalent(fst1, fst2, std::get<2>(args->args), std::get<3>(args->args));
 }
 
-bool Equivalent(const FstClass &fst1, const FstClass &fst2,
+bool fstscript_EXPORT Equivalent(const FstClass &fst1, const FstClass &fst2,
                 float delta = kDelta, bool *error = nullptr);
 
 }  // namespace script

--- a/src/include/fst/script/fst-class.h
+++ b/src/include/fst/script/fst-class.h
@@ -42,6 +42,7 @@
 #include <fst/script/arc-class.h>
 #include <fst/script/weight-class.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 // Classes to support "boxing" all existing types of FST arcs in a single
 // FstClass which hides the arc types. This allows clients to load
@@ -57,7 +58,7 @@ namespace script {
 // hierarchy bifurcates; FstClassImplBase serves as the base class for all
 // implementations (of which FstClassImpl is currently the only one) and
 // FstClass serves as the base class for all interfaces.
-class FstClassBase {
+class fstscript_EXPORT FstClassBase {
  public:
   virtual const std::string &ArcType() const = 0;
   virtual WeightClass Final(int64_t) const = 0;
@@ -302,9 +303,9 @@ class FstClassImpl : public FstClassImplBase {
 
 // BASE CLASS DEFINITIONS
 
-class MutableFstClass;
+class fstscript_EXPORT MutableFstClass;
 
-class FstClass : public FstClassBase {
+class fstscript_EXPORT FstClass : public FstClassBase {
  public:
   FstClass() : impl_(nullptr) {}
 
@@ -549,7 +550,7 @@ class MutableFstClass : public FstClass {
       : FstClass(std::move(impl)) {}
 };
 
-class VectorFstClass : public MutableFstClass {
+class fstscript_EXPORT VectorFstClass : public MutableFstClass {
  public:
   explicit VectorFstClass(std::unique_ptr<FstClassImplBase> impl)
       : MutableFstClass(std::move(impl)) {}
@@ -630,7 +631,15 @@ class FstClassIORegister
   std::string ConvertKeyToSoFilename(std::string_view key) const final {
     std::string legal_type(key);
     ConvertToLegalCSymbol(&legal_type);
-    legal_type.append("-arc.so");
+    legal_type.append("-arc");
+    #ifdef _WIN32
+        legal_type.append(".dll");
+    #elif defined __APPLE__
+        legal_type.append(".dylib");
+    #else
+        legal_type.append(".so");
+
+    #endif // _WIN32
     return legal_type;
   }
 };

--- a/src/include/fst/script/getters.h
+++ b/src/include/fst/script/getters.h
@@ -42,35 +42,36 @@
 #include <fst/script/map.h>             // For MapType.
 #include <fst/script/script-impl.h>     // For RandArcSelection.
 #include <string_view>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
 inline constexpr uint64_t kDefaultSeed = std::numeric_limits<uint64_t>::max();
 
-bool GetArcFilterType(std::string_view str, ArcFilterType *arc_filter_type);
+bool fstscript_EXPORT GetArcFilterType(std::string_view str, ArcFilterType *arc_filter_type);
 
-bool GetArcSortType(std::string_view str, ArcSortType *sort_type);
+bool fstscript_EXPORT GetArcSortType(std::string_view str, ArcSortType *sort_type);
 
-bool GetClosureType(std::string_view str, ClosureType *closure_type);
+bool fstscript_EXPORT GetClosureType(std::string_view str, ClosureType *closure_type);
 
-bool GetComposeFilter(std::string_view str, ComposeFilter *compose_filter);
+bool fstscript_EXPORT GetComposeFilter(std::string_view str, ComposeFilter *compose_filter);
 
-bool GetDeterminizeType(std::string_view str, DeterminizeType *det_type);
+bool fstscript_EXPORT GetDeterminizeType(std::string_view str, DeterminizeType *det_type);
 
-inline uint8_t GetEncodeFlags(bool encode_labels, bool encode_weights) {
+inline uint8_t fstscript_EXPORT GetEncodeFlags(bool encode_labels, bool encode_weights) {
   return (encode_labels ? kEncodeLabels : 0) |
          (encode_weights ? kEncodeWeights : 0);
 }
 
-bool GetEpsNormalizeType(std::string_view str,
+bool fstscript_EXPORT GetEpsNormalizeType(std::string_view str,
                          EpsNormalizeType *eps_norm_type);
 
-bool GetMapType(std::string_view str, MapType *map_type);
+bool fstscript_EXPORT GetMapType(std::string_view str, MapType *map_type);
 
-bool GetProjectType(std::string_view str, ProjectType *project_type);
+bool fstscript_EXPORT GetProjectType(std::string_view str, ProjectType *project_type);
 
-inline uint8_t GetPushFlags(bool push_weights, bool push_labels,
+inline uint8_t fstscript_EXPORT GetPushFlags(bool push_weights, bool push_labels,
                             bool remove_total_weight,
                             bool remove_common_affix) {
   return ((push_weights ? kPushWeights : 0) | (push_labels ? kPushLabels : 0) |
@@ -78,18 +79,18 @@ inline uint8_t GetPushFlags(bool push_weights, bool push_labels,
           (remove_common_affix ? kPushRemoveCommonAffix : 0));
 }
 
-bool GetQueueType(std::string_view str, QueueType *queue_type);
+bool fstscript_EXPORT GetQueueType(std::string_view str, QueueType *queue_type);
 
-bool GetRandArcSelection(std::string_view str, RandArcSelection *ras);
+bool fstscript_EXPORT GetRandArcSelection(std::string_view str, RandArcSelection *ras);
 
-bool GetReplaceLabelType(std::string_view str, bool epsilon_on_replace,
+bool fstscript_EXPORT GetReplaceLabelType(std::string_view str, bool epsilon_on_replace,
                          ReplaceLabelType *rlt);
 
-bool GetReweightType(std::string_view str, ReweightType *reweight_type);
+bool fstscript_EXPORT GetReweightType(std::string_view str, ReweightType *reweight_type);
 
-uint64_t GetSeed(uint64_t seed);
+uint64_t fstscript_EXPORT GetSeed(uint64_t seed);
 
-bool GetTokenType(std::string_view str, TokenType *token_type);
+bool fstscript_EXPORT GetTokenType(std::string_view str, TokenType *token_type);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/info-impl.h
+++ b/src/include/fst/script/info-impl.h
@@ -42,6 +42,7 @@
 #include <fst/visit.h>
 #include <fst/script/arcfilter-impl.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 namespace fst {
 
@@ -49,7 +50,7 @@ namespace fst {
 // WARNING: Stand-alone use of this class is not recommended, most code
 // should call directly the relevant library functions: Fst<Arc>::NumStates,
 // Fst<Arc>::NumArcs, TestProperties, etc.
-class FstInfo {
+class fstscript_EXPORT FstInfo {
  public:
   // When info_type is "short" (or "auto" and not an ExpandedFst) then only
   // minimal info is computed and can be requested.
@@ -342,10 +343,10 @@ class FstInfo {
 };
 
 // Prints `properties` to `ostrm` in a user-friendly multi-line format.
-void PrintProperties(std::ostream &ostrm, uint64_t properties);
+void fstscript_EXPORT PrintProperties(std::ostream &ostrm, uint64_t properties);
 
 // Prints `header` to `ostrm` in a user-friendly multi-line format.
-void PrintHeader(std::ostream &ostrm, const FstHeader &header);
+void fstscript_EXPORT PrintHeader(std::ostream &ostrm, const FstHeader &header);
 
 }  // namespace fst
 

--- a/src/include/fst/script/info.h
+++ b/src/include/fst/script/info.h
@@ -26,6 +26,7 @@
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
 #include <fst/script/info-impl.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -41,7 +42,7 @@ void Info(FstInfoArgs *args) {
   info.Info();
 }
 
-void Info(const FstClass &fst, bool test_properties, ArcFilterType arc_filter,
+void fstscript_EXPORT Info(const FstClass &fst, bool test_properties, ArcFilterType arc_filter,
           const std::string &info_type, bool verify);
 
 }  // namespace script

--- a/src/include/fst/script/intersect.h
+++ b/src/include/fst/script/intersect.h
@@ -26,6 +26,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/script/compose.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -42,7 +43,7 @@ void Intersect(FstIntersectArgs *args) {
   Intersect(ifst1, ifst2, ofst, opts);
 }
 
-void Intersect(const FstClass &ifst, const FstClass &ifst2,
+void fstscript_EXPORT Intersect(const FstClass &ifst, const FstClass &ifst2,
                MutableFstClass *ofst,
                const ComposeOptions &opts = ComposeOptions());
 

--- a/src/include/fst/script/invert.h
+++ b/src/include/fst/script/invert.h
@@ -20,6 +20,7 @@
 
 #include <fst/invert.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -29,7 +30,7 @@ void Invert(MutableFstClass *fst) {
   Invert(fst->GetMutableFst<Arc>());
 }
 
-void Invert(MutableFstClass *fst);
+void fstscript_EXPORT Invert(MutableFstClass *fst);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/isomorphic.h
+++ b/src/include/fst/script/isomorphic.h
@@ -25,6 +25,7 @@
 #include <fst/weight.h>
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -41,7 +42,7 @@ void Isomorphic(FstIsomorphicArgs *args) {
   args->retval = Isomorphic(fst1, fst2, std::get<2>(args->args));
 }
 
-bool Isomorphic(const FstClass &fst1, const FstClass &fst2,
+bool fstscript_EXPORT Isomorphic(const FstClass &fst1, const FstClass &fst2,
                 float delta = kDelta);
 
 }  // namespace script

--- a/src/include/fst/script/map.h
+++ b/src/include/fst/script/map.h
@@ -31,6 +31,7 @@
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
 #include <fst/script/weight-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -53,7 +54,7 @@ std::unique_ptr<Fst<typename M::ToArc>> StateMap(
   return ofst;
 }
 
-enum class MapType : uint8_t {
+enum class fstscript_EXPORT MapType : uint8_t {
   ARC_SUM,
   ARC_UNIQUE,
   IDENTITY,
@@ -164,7 +165,7 @@ void Map(FstMapArgs *args) {
   }
 }
 
-std::unique_ptr<FstClass> Map(const FstClass &ifst,
+std::unique_ptr<FstClass> fstscript_EXPORT Map(const FstClass &ifst,
                                               MapType map_type, float delta,
                                               double power,
                                               const WeightClass &weight);

--- a/src/include/fst/script/minimize.h
+++ b/src/include/fst/script/minimize.h
@@ -24,6 +24,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/shortest-distance.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -39,7 +40,7 @@ void Minimize(FstMinimizeArgs *args) {
   Minimize(ofst1, ofst2, std::get<2>(*args), std::get<3>(*args));
 }
 
-void Minimize(MutableFstClass *ofst1,
+void fstscript_EXPORT Minimize(MutableFstClass *ofst1,
               MutableFstClass * ofst2 = nullptr,
               float delta = kShortestDelta, bool allow_nondet = false);
 

--- a/src/include/fst/script/print.h
+++ b/src/include/fst/script/print.h
@@ -27,8 +27,7 @@
 #include <fst/script/fst-class.h>
 #include <fst/script/print-impl.h>
 #include <string_view>
-
-DECLARE_string(fst_field_separator);
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -36,7 +35,7 @@ namespace script {
 // Note: it is safe to pass these strings as references because this struct is
 // only used to pass them deeper in the call graph. Be sure you understand why
 // this is so before using this struct for anything else!
-struct FstPrintArgs {
+struct fstscript_EXPORT FstPrintArgs {
   const FstClass &fst;
   const SymbolTable *isyms;
   const SymbolTable *osyms;
@@ -58,14 +57,14 @@ void Print(FstPrintArgs *args) {
   fstprinter.Print(args->ostrm, args->dest);
 }
 
-void Print(const FstClass &fst, std::ostream &ostrm, const std::string &dest,
+void fstscript_EXPORT Print(const FstClass &fst, std::ostream &ostrm, const std::string &dest,
            const SymbolTable *isyms = nullptr,
            const SymbolTable *osyms = nullptr,
            const SymbolTable *ssyms = nullptr, bool accept = true,
            bool show_weight_one = true, const std::string &missing_sym = "");
 
 // TODO(kbg,2019-09-01): Deprecated.
-void PrintFst(const FstClass &fst, std::ostream &ostrm, const std::string &dest,
+void fstscript_EXPORT PrintFst(const FstClass &fst, std::ostream &ostrm, const std::string &dest,
               const SymbolTable *isyms, const SymbolTable *osyms,
               const SymbolTable *ssyms, bool accept, bool show_weight_one,
               const std::string &missing_sym = "");

--- a/src/include/fst/script/project.h
+++ b/src/include/fst/script/project.h
@@ -23,6 +23,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/project.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -35,7 +36,7 @@ void Project(FstProjectArgs *args) {
   Project(fst, std::get<1>(*args));
 }
 
-void Project(MutableFstClass *fst, ProjectType project_type);
+void fstscript_EXPORT Project(MutableFstClass *fst, ProjectType project_type);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/prune.h
+++ b/src/include/fst/script/prune.h
@@ -31,6 +31,7 @@
 #include <fst/weight.h>
 #include <fst/script/fst-class.h>
 #include <fst/script/weight-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -68,11 +69,11 @@ void Prune(FstPruneArgs2 *args) {
   }
 }
 
-void Prune(const FstClass &ifst, MutableFstClass *ofst,
+void fstscript_EXPORT Prune(const FstClass &ifst, MutableFstClass *ofst,
            const WeightClass &weight_threshold,
            int64_t state_threshold = kNoStateId, float delta = kDelta);
 
-void Prune(MutableFstClass *fst, const WeightClass &weight_threshold,
+void fstscript_EXPORT Prune(MutableFstClass *fst, const WeightClass &weight_threshold,
            int64_t state_threshold = kNoStateId, float delta = kDelta);
 
 }  // namespace script

--- a/src/include/fst/script/push.h
+++ b/src/include/fst/script/push.h
@@ -27,6 +27,7 @@
 #include <fst/reweight.h>
 #include <fst/shortest-distance.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -60,10 +61,10 @@ void Push(FstPushArgs2 *args) {
   }
 }
 
-void Push(MutableFstClass *fst, ReweightType type = REWEIGHT_TO_INITIAL,
+void fstscript_EXPORT Push(MutableFstClass *fst, ReweightType type = REWEIGHT_TO_INITIAL,
           float delta = kShortestDelta, bool remove_total_weight = false);
 
-void Push(const FstClass &ifst, MutableFstClass *ofst, uint8_t flags,
+void fstscript_EXPORT Push(const FstClass &ifst, MutableFstClass *ofst, uint8_t flags,
           ReweightType rew_type, float delta = kShortestDelta);
 
 }  // namespace script

--- a/src/include/fst/script/randequivalent.h
+++ b/src/include/fst/script/randequivalent.h
@@ -29,6 +29,7 @@
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
 #include <fst/script/script-impl.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -72,7 +73,7 @@ void RandEquivalent(FstRandEquivalentArgs *args) {
   }
 }
 
-bool RandEquivalent(
+bool fstscript_EXPORT RandEquivalent(
     const FstClass &fst1, const FstClass &fst2, int32_t npath = 1,
     const RandGenOptions<RandArcSelection> &opts =
         RandGenOptions<RandArcSelection>(RandArcSelection::UNIFORM),

--- a/src/include/fst/script/randgen.h
+++ b/src/include/fst/script/randgen.h
@@ -27,6 +27,7 @@
 #include <fst/randgen.h>
 #include <fst/script/fst-class.h>
 #include <fst/script/script-impl.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -69,7 +70,7 @@ void RandGen(FstRandGenArgs *args) {
   }
 }
 
-void RandGen(const FstClass &ifst, MutableFstClass *ofst,
+void fstscript_EXPORT RandGen(const FstClass &ifst, MutableFstClass *ofst,
              const RandGenOptions<RandArcSelection> &opts =
                  RandGenOptions<RandArcSelection>(RandArcSelection::UNIFORM),
              uint64_t seed = std::random_device()());

--- a/src/include/fst/script/relabel.h
+++ b/src/include/fst/script/relabel.h
@@ -29,6 +29,7 @@
 #include <fst/relabel.h>
 #include <fst/symbol-table.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -66,13 +67,13 @@ void Relabel(FstRelabelArgs2 *args) {
   Relabel(ofst, typed_ipairs, typed_opairs);
 }
 
-void Relabel(MutableFstClass *ofst, const SymbolTable *old_isymbols,
+void fstscript_EXPORT Relabel(MutableFstClass *ofst, const SymbolTable *old_isymbols,
              const SymbolTable *new_isymbols,
              const std::string &unknown_isymbol, bool attach_new_isymbols,
              const SymbolTable *old_osymbols, const SymbolTable *new_osymbols,
              const std::string &unknown_osymbol, bool attach_new_osymbols);
 
-void Relabel(MutableFstClass *ofst,
+void fstscript_EXPORT Relabel(MutableFstClass *ofst,
              const std::vector<std::pair<int64_t, int64_t>> &ipairs,
              const std::vector<std::pair<int64_t, int64_t>> &opairs);
 

--- a/src/include/fst/script/replace.h
+++ b/src/include/fst/script/replace.h
@@ -31,11 +31,12 @@
 #include <fst/replace.h>
 #include <fst/util.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
-struct ReplaceOptions {
+struct fstscript_EXPORT ReplaceOptions {
   const int64_t root;                        // Root rule for expansion.
   const ReplaceLabelType call_label_type;    // How to label call arc.
   const ReplaceLabelType return_label_type;  // How to label return arc.
@@ -82,7 +83,7 @@ void Replace(FstReplaceArgs *args) {
   *ofst = rfst;
 }
 
-void Replace(const std::vector<std::pair<int64_t, const FstClass *>> &pairs,
+void fstscript_EXPORT Replace(const std::vector<std::pair<int64_t, const FstClass *>> &pairs,
              MutableFstClass *ofst, const ReplaceOptions &opts);
 
 }  // namespace script

--- a/src/include/fst/script/reverse.h
+++ b/src/include/fst/script/reverse.h
@@ -24,6 +24,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/reverse.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -37,7 +38,7 @@ void Reverse(FstReverseArgs *args) {
   Reverse(ifst, ofst, std::get<2>(*args));
 }
 
-void Reverse(const FstClass &ifst, MutableFstClass *ofst,
+void fstscript_EXPORT Reverse(const FstClass &ifst, MutableFstClass *ofst,
              bool require_superinitial = true);
 
 }  // namespace script

--- a/src/include/fst/script/reweight.h
+++ b/src/include/fst/script/reweight.h
@@ -26,6 +26,7 @@
 #include <fst/script/fst-class.h>
 #include <fst/script/script-impl.h>
 #include <fst/script/weight-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -44,7 +45,7 @@ void Reweight(FstReweightArgs *args) {
   Reweight(fst, typed_potentials, std::get<2>(*args));
 }
 
-void Reweight(MutableFstClass *fst, const std::vector<WeightClass> &potentials,
+void fstscript_EXPORT Reweight(MutableFstClass *fst, const std::vector<WeightClass> &potentials,
               ReweightType reweight_type);
 
 }  // namespace script

--- a/src/include/fst/script/rmepsilon.h
+++ b/src/include/fst/script/rmepsilon.h
@@ -35,11 +35,12 @@
 #include <fst/script/fst-class.h>
 #include <fst/script/shortest-distance.h>
 #include <fst/script/weight-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
-struct RmEpsilonOptions : public ShortestDistanceOptions {
+struct fstscript_EXPORT RmEpsilonOptions : public ShortestDistanceOptions {
   const bool connect;
   const WeightClass &weight_threshold;
   const int64_t state_threshold;
@@ -130,7 +131,7 @@ void RmEpsilon(FstRmEpsilonArgs *args) {
   internal::RmEpsilon(fst, opts);
 }
 
-void RmEpsilon(MutableFstClass *fst, const RmEpsilonOptions &opts);
+void fstscript_EXPORT RmEpsilon(MutableFstClass *fst, const RmEpsilonOptions &opts);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/script-impl.h
+++ b/src/include/fst/script/script-impl.h
@@ -108,11 +108,12 @@
 #include <fst/script/fst-class.h>
 #include <fst/script/weight-class.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
-enum class RandArcSelection : uint8_t { UNIFORM, LOG_PROB, FAST_LOG_PROB };
+enum class fstscript_EXPORT RandArcSelection : uint8_t { UNIFORM, LOG_PROB, FAST_LOG_PROB };
 
 // A generic register for operations with various kinds of signatures.
 // Needed since every function signature requires a new registration class.
@@ -136,7 +137,15 @@ class GenericOperationRegister
     // Uses the old-style FST for now.
     std::string legal_type(key.second);  // The arc type.
     ConvertToLegalCSymbol(&legal_type);
-    legal_type.append("-arc.so");
+    legal_type.append("-arc");
+    #ifdef _WIN32
+        legal_type.append(".dll");
+    #elif defined __APPLE__
+        legal_type.append(".dylib");
+    #else
+        legal_type.append(".so");
+
+    #endif // _WIN32
     return legal_type;
   }
 };

--- a/src/include/fst/script/shortest-distance.h
+++ b/src/include/fst/script/shortest-distance.h
@@ -37,11 +37,12 @@
 #include <fst/script/prune.h>
 #include <fst/script/script-impl.h>
 #include <fst/script/weight-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
-struct ShortestDistanceOptions {
+struct fstscript_EXPORT ShortestDistanceOptions {
   const QueueType queue_type;
   const ArcFilterType arc_filter_type;
   const int64_t source;
@@ -237,14 +238,14 @@ void ShortestDistance(FstShortestDistanceArgs3 *args) {
   args->retval = WeightClass(ShortestDistance(fst, std::get<1>(args->args)));
 }
 
-void ShortestDistance(const FstClass &fst, std::vector<WeightClass> *distance,
+void fstscript_EXPORT ShortestDistance(const FstClass &fst, std::vector<WeightClass> *distance,
                       const ShortestDistanceOptions &opts);
 
-void ShortestDistance(const FstClass &ifst, std::vector<WeightClass> *distance,
+void fstscript_EXPORT ShortestDistance(const FstClass &ifst, std::vector<WeightClass> *distance,
                       bool reverse = false,
                       double delta = fst::kShortestDelta);
 
-WeightClass ShortestDistance(const FstClass &ifst,
+WeightClass fstscript_EXPORT ShortestDistance(const FstClass &ifst,
                              double delta = fst::kShortestDelta);
 
 }  // namespace script

--- a/src/include/fst/script/shortest-path.h
+++ b/src/include/fst/script/shortest-path.h
@@ -36,13 +36,14 @@
 #include <fst/script/fst-class.h>
 #include <fst/script/shortest-distance.h>
 #include <fst/script/weight-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
 // Slightly simplified interface: `has_distance` and `first_path` are disabled.
 
-struct ShortestPathOptions : public ShortestDistanceOptions {
+struct fstscript_EXPORT ShortestPathOptions : public ShortestDistanceOptions {
   const int32_t nshortest;
   const bool unique;
   const WeightClass &weight_threshold;
@@ -143,7 +144,7 @@ void ShortestPath(FstShortestPathArgs *args) {
   internal::ShortestPath(ifst, ofst, opts);
 }
 
-void ShortestPath(const FstClass &ifst, MutableFstClass *ofst,
+void fstscript_EXPORT ShortestPath(const FstClass &ifst, MutableFstClass *ofst,
                   const ShortestPathOptions &opts);
 
 }  // namespace script

--- a/src/include/fst/script/stateiterator-class.h
+++ b/src/include/fst/script/stateiterator-class.h
@@ -25,6 +25,7 @@
 #include <fst/fst.h>
 #include <fst/fstlib.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 // Scripting API support for StateIterator.
 
@@ -32,7 +33,7 @@ namespace fst {
 namespace script {
 
 // Virtual interface implemented by each concrete StateIteratorImpl<F>.
-class StateIteratorImplBase {
+class fstscript_EXPORT StateIteratorImplBase {
  public:
   virtual bool Done() const = 0;
   virtual int64_t Value() const = 0;
@@ -61,7 +62,7 @@ class StateIteratorClassImpl : public StateIteratorImplBase {
   StateIterator<Fst<Arc>> siter_;
 };
 
-class StateIteratorClass;
+class fstscript_EXPORT StateIteratorClass;
 
 using InitStateIteratorClassArgs =
     std::pair<const FstClass &, StateIteratorClass *>;

--- a/src/include/fst/script/synchronize.h
+++ b/src/include/fst/script/synchronize.h
@@ -24,6 +24,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/synchronize.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -37,7 +38,7 @@ void Synchronize(FstSynchronizeArgs *args) {
   Synchronize(ifst, ofst);
 }
 
-void Synchronize(const FstClass &ifst, MutableFstClass *ofst);
+void fstscript_EXPORT Synchronize(const FstClass &ifst, MutableFstClass *ofst);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/text-io.h
+++ b/src/include/fst/script/text-io.h
@@ -27,14 +27,15 @@
 
 #include <fst/script/weight-class.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
-bool ReadPotentials(std::string_view weight_type, const std::string &source,
+bool fstscript_EXPORT ReadPotentials(std::string_view weight_type, const std::string &source,
                     std::vector<WeightClass> *potentials);
 
-bool WritePotentials(const std::string &source,
+bool fstscript_EXPORT WritePotentials(const std::string &source,
                      const std::vector<WeightClass> &potentials);
 
 }  // namespace script

--- a/src/include/fst/script/topsort.h
+++ b/src/include/fst/script/topsort.h
@@ -21,6 +21,7 @@
 #include <fst/topsort.h>
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -32,7 +33,7 @@ void TopSort(FstTopSortArgs *args) {
   args->retval = TopSort(args->args->GetMutableFst<Arc>());
 }
 
-bool TopSort(MutableFstClass *fst);
+bool fstscript_EXPORT TopSort(MutableFstClass *fst);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/union.h
+++ b/src/include/fst/script/union.h
@@ -26,6 +26,7 @@
 #include <fst/mutable-fst.h>
 #include <fst/union.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -54,9 +55,9 @@ void Union(FstUnionArgs2 *args) {
   Union(fst1, typed_fsts2);
 }
 
-void Union(MutableFstClass *fst1, const FstClass &fst2);
+void fstscript_EXPORT Union(MutableFstClass *fst1, const FstClass &fst2);
 
-void Union(MutableFstClass *fst1, const std::vector<const FstClass *> &fsts2);
+void fstscript_EXPORT Union(MutableFstClass *fst1, const std::vector<const FstClass *> &fsts2);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/verify.h
+++ b/src/include/fst/script/verify.h
@@ -22,6 +22,7 @@
 #include <fst/verify.h>
 #include <fst/script/arg-packs.h>
 #include <fst/script/fst-class.h>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
@@ -34,7 +35,7 @@ void Verify(FstVerifyArgs *args) {
   args->retval = Verify(fst);
 }
 
-bool Verify(const FstClass &fst);
+bool fstscript_EXPORT Verify(const FstClass &fst);
 
 }  // namespace script
 }  // namespace fst

--- a/src/include/fst/script/weight-class.h
+++ b/src/include/fst/script/weight-class.h
@@ -31,11 +31,12 @@
 #include <fst/util.h>
 #include <fst/weight.h>
 #include <string_view>
+#include <fst/exports/exports.h>
 
 namespace fst {
 namespace script {
 
-class WeightImplBase {
+class fstscript_EXPORT WeightImplBase {
  public:
   virtual WeightImplBase *Copy() const = 0;
   virtual void Print(std::ostream *o) const = 0;
@@ -108,7 +109,7 @@ class WeightClassImpl : public WeightImplBase {
   W weight_;
 };
 
-class WeightClass {
+class fstscript_EXPORT WeightClass {
  public:
   WeightClass() = default;
 
@@ -163,15 +164,15 @@ class WeightClass {
   static bool WeightTypesMatch(const WeightClass &lhs, const WeightClass &rhs,
                                std::string_view op_name);
 
-  friend bool operator==(const WeightClass &lhs, const WeightClass &rhs);
+  friend bool fstscript_EXPORT operator==(const WeightClass &lhs, const WeightClass &rhs);
 
-  friend WeightClass Plus(const WeightClass &lhs, const WeightClass &rhs);
+  friend WeightClass fstscript_EXPORT Plus(const WeightClass &lhs, const WeightClass &rhs);
 
-  friend WeightClass Times(const WeightClass &lhs, const WeightClass &rhs);
+  friend WeightClass fstscript_EXPORT Times(const WeightClass &lhs, const WeightClass &rhs);
 
-  friend WeightClass Divide(const WeightClass &lhs, const WeightClass &rhs);
+  friend WeightClass fstscript_EXPORT Divide(const WeightClass &lhs, const WeightClass &rhs);
 
-  friend WeightClass Power(const WeightClass &w, size_t n);
+  friend WeightClass fstscript_EXPORT Power(const WeightClass &w, size_t n);
 
  private:
   const WeightImplBase *GetImpl() const { return impl_.get(); }
@@ -180,22 +181,22 @@ class WeightClass {
 
   std::unique_ptr<WeightImplBase> impl_;
 
-  friend std::ostream &operator<<(std::ostream &o, const WeightClass &c);
+  friend std::ostream fstscript_EXPORT &operator<<(std::ostream &o, const WeightClass &c);
 };
 
-bool operator==(const WeightClass &lhs, const WeightClass &rhs);
+bool fstscript_EXPORT operator==(const WeightClass &lhs, const WeightClass &rhs);
 
-bool operator!=(const WeightClass &lhs, const WeightClass &rhs);
+bool fstscript_EXPORT operator!=(const WeightClass &lhs, const WeightClass &rhs);
 
-WeightClass Plus(const WeightClass &lhs, const WeightClass &rhs);
+WeightClass fstscript_EXPORT Plus(const WeightClass &lhs, const WeightClass &rhs);
 
-WeightClass Times(const WeightClass &lhs, const WeightClass &rhs);
+WeightClass fstscript_EXPORT Times(const WeightClass &lhs, const WeightClass &rhs);
 
-WeightClass Divide(const WeightClass &lhs, const WeightClass &rhs);
+WeightClass fstscript_EXPORT Divide(const WeightClass &lhs, const WeightClass &rhs);
 
-WeightClass Power(const WeightClass &w, size_t n);
+WeightClass fstscript_EXPORT Power(const WeightClass &w, size_t n);
 
-std::ostream &operator<<(std::ostream &o, const WeightClass &c);
+std::ostream fstscript_EXPORT &operator<<(std::ostream &o, const WeightClass &c);
 
 // Registration for generic weight types.
 
@@ -221,7 +222,14 @@ class WeightClassRegister
   std::string ConvertKeyToSoFilename(std::string_view key) const final {
     std::string legal_type(key);
     ConvertToLegalCSymbol(&legal_type);
-    legal_type.append(".so");
+    #ifdef _WIN32
+        legal_type.append(".dll");
+    #elif defined __APPLE__
+        legal_type.append(".dylib");
+    #else
+        legal_type.append(".so");
+
+    #endif // _WIN32
     return legal_type;
   }
 };

--- a/src/include/fst/string.h
+++ b/src/include/fst/string.h
@@ -42,7 +42,7 @@
 #include <fst/compat.h>
 #include <string_view>
 
-DECLARE_string(fst_field_separator);
+DECLARE_export_string(fst_field_separator, fst_EXPORT);
 
 namespace fst {
 

--- a/src/include/fst/symbol-table-ops.h
+++ b/src/include/fst/symbol-table-ops.h
@@ -53,7 +53,7 @@ SymbolTable *PruneSymbolTable(const Fst<Arc> &fst, const SymbolTable &syms,
 }
 
 // Relabels a symbol table to make it a contiguous mapping.
-SymbolTable *CompactSymbolTable(const SymbolTable &syms);
+SymbolTable fst_EXPORT *CompactSymbolTable(const SymbolTable &syms);
 
 // Merges two SymbolTables, all symbols from left will be merged into right
 // with the same IDs. Symbols in right that have conflicting IDs with those
@@ -72,19 +72,19 @@ SymbolTable *CompactSymbolTable(const SymbolTable &syms);
 //                                     b.InputSymbols(), &relabel);
 //   if (relabel) Relabel(b, bnew.get(), nullptr);
 //   b.SetInputSymbols(bnew);
-SymbolTable *MergeSymbolTable(const SymbolTable &left, const SymbolTable &right,
+SymbolTable fst_EXPORT *MergeSymbolTable(const SymbolTable &left, const SymbolTable &right,
                               bool *right_relabel_output = nullptr);
 
 // Read the symbol table from any Fst::Read()able file, without loading the
 // corresponding FST. Returns nullptr if the FST does not contain a symbol
 // table or the symbol table cannot be read.
-SymbolTable * FstReadSymbols(const std::string &source,
+SymbolTable fst_EXPORT * FstReadSymbols(const std::string &source,
                                              bool input);
 
 // Adds a contiguous range of symbols to a symbol table using a simple prefix
 // for the string, returning false if the inserted symbol string clashes with
 // any currently present.
-bool AddAuxiliarySymbols(const std::string &prefix, int64_t start_label,
+bool fst_EXPORT AddAuxiliarySymbols(const std::string &prefix, int64_t start_label,
                          int64_t nlabels, SymbolTable *syms);
 
 }  // namespace fst

--- a/src/include/fst/symbol-table.h
+++ b/src/include/fst/symbol-table.h
@@ -47,14 +47,14 @@
 #include <string_view>
 #include <fst/lock.h>
 
-DECLARE_bool(fst_compat_symbols);
-DECLARE_string(fst_field_separator);
+DECLARE_export_bool(fst_compat_symbols, fst_EXPORT);
+DECLARE_export_string(fst_field_separator, fst_EXPORT);
 
 namespace fst {
 
 inline constexpr int64_t kNoSymbol = -1;
 
-class SymbolTable;
+class fst_EXPORT SymbolTable;
 
 namespace internal {
 
@@ -583,14 +583,14 @@ SymbolTable *RelabelSymbolTable(
 
 // Returns true if the two symbol tables have equal checksums. Passing in
 // nullptr for either table always returns true.
-bool CompatSymbols(const SymbolTable *syms1, const SymbolTable *syms2,
+bool fst_EXPORT CompatSymbols(const SymbolTable *syms1, const SymbolTable *syms2,
                    bool warning = true);
 
 // Symbol table serialization.
 
-void SymbolTableToString(const SymbolTable *table, std::string *result);
+void fst_EXPORT SymbolTableToString(const SymbolTable *table, std::string *result);
 
-SymbolTable *StringToSymbolTable(const std::string &str);
+SymbolTable fst_EXPORT *StringToSymbolTable(const std::string &str);
 
 }  // namespace fst
 

--- a/src/include/fst/test-properties.h
+++ b/src/include/fst/test-properties.h
@@ -33,8 +33,6 @@
 #include <fst/util.h>
 #include <unordered_set>
 
-DECLARE_bool(fst_verify_properties);
-
 namespace fst {
 namespace internal {
 

--- a/src/include/fst/test/fst_test.h
+++ b/src/include/fst/test/fst_test.h
@@ -240,13 +240,13 @@ class FstTester {
     {
       // check mmaping by first writing the file with the aligned attribute set
       {
-        std::ofstream ostr(aligned);
+        std::ofstream ostr(aligned, std::ios_base::binary);
         FstWriteOptions opts;
         opts.source = aligned;
         opts.align = true;
         CHECK(fst.Write(ostr, opts));
       }
-      std::ifstream istr(aligned);
+      std::ifstream istr(aligned, std::ios_base::binary);
       FstReadOptions opts;
       opts.mode = FstReadOptions::ReadMode("map");
       opts.source = aligned;
@@ -258,13 +258,13 @@ class FstTester {
     // check mmaping of unaligned files to make sure it does not fail.
     {
       {
-        std::ofstream ostr(aligned);
+        std::ofstream ostr(aligned, std::ios_base::binary);
         FstWriteOptions opts;
         opts.source = aligned;
         opts.align = false;
         CHECK(fst.Write(ostr, opts));
       }
-      std::ifstream istr(aligned);
+      std::ifstream istr(aligned, std::ios_base::binary);
       FstReadOptions opts;
       opts.mode = FstReadOptions::ReadMode("map");
       opts.source = aligned;

--- a/src/include/fst/util.h
+++ b/src/include/fst/util.h
@@ -51,7 +51,7 @@
 
 // Utility for error handling.
 
-DECLARE_bool(fst_error_fatal);
+DECLARE_export_bool(fst_error_fatal, fst_EXPORT);
 
 #define FSTERROR()                                                     \
   (FST_FLAGS_fst_error_fatal ? LOG(FATAL) : LOG(ERROR))
@@ -338,9 +338,9 @@ std::ostream &WriteType(std::ostream &strm, const std::unordered_set<T...> &c) {
 // string should consist only of digits (no prefixes such as "0x") and an
 // optionally preceding minus. Returns a value iff the entirety of the string is
 // consumed during integer parsing, otherwise returns `std::nullopt`.
-std::optional<int64_t> ParseInt64(std::string_view s, int base = 10);
+std::optional<int64_t> fst_EXPORT ParseInt64(std::string_view s, int base = 10);
 
-int64_t StrToInt64(std::string_view s, std::string_view source, size_t nline,
+int64_t fst_EXPORT StrToInt64(std::string_view s, std::string_view source, size_t nline,
                    bool * error = nullptr);
 
 template <typename Weight>
@@ -368,7 +368,7 @@ std::string WeightToStr(Weight w) {
 template <typename I>
 bool ReadIntPairs(std::string_view source,
                   std::vector<std::pair<I, I>> *pairs) {
-  std::ifstream strm(std::string(source), std::ios_base::in);
+  std::ifstream strm(std::string(source), std::ios_base::in | std::ios_base::binary);
   if (!strm) {
     LOG(ERROR) << "ReadIntPairs: Can't open file: " << source;
     return false;
@@ -403,7 +403,7 @@ bool WriteIntPairs(std::string_view source,
                    const std::vector<std::pair<I, I>> &pairs) {
   std::ofstream fstrm;
   if (!source.empty()) {
-    fstrm.open(std::string(source));
+    fstrm.open(std::string(source), std::ios_base::out | std::ios_base::binary);
     if (!fstrm) {
       LOG(ERROR) << "WriteIntPairs: Can't open file: " << source;
       return false;
@@ -432,12 +432,12 @@ bool WriteLabelPairs(std::string_view source,
 
 // Utilities for converting a type name to a legal C symbol.
 
-void ConvertToLegalCSymbol(std::string *s);
+void fst_EXPORT ConvertToLegalCSymbol(std::string *s);
 
 // Utilities for stream I/O.
 
-bool AlignInput(std::istream &strm, size_t align = MappedFile::kArchAlignment);
-bool AlignOutput(std::ostream &strm, size_t align = MappedFile::kArchAlignment);
+bool fst_EXPORT AlignInput(std::istream &strm, size_t align = MappedFile::kArchAlignment);
+bool fst_EXPORT AlignOutput(std::ostream &strm, size_t align = MappedFile::kArchAlignment);
 
 // An associative container for which testing membership is faster than an STL
 // set if members are restricted to an interval that excludes most non-members.

--- a/src/include/fst/vector-fst.h
+++ b/src/include/fst/vector-fst.h
@@ -491,7 +491,7 @@ VectorFstImpl<S> *VectorFstImpl<S>::Read(std::istream &strm,
     int64_t narcs;
     ReadType(strm, &narcs);
     if (!strm) {
-      LOG(ERROR) << "VectorFst::Read: Read failed: " << opts.source;
+      LOG(ERROR) << "VectorFst::Read: State read failed: " << opts.source;
       return nullptr;
     }
     impl->ReserveArcs(state, narcs);
@@ -502,7 +502,7 @@ VectorFstImpl<S> *VectorFstImpl<S>::Read(std::istream &strm,
       arc.weight.Read(strm);
       ReadType(strm, &arc.nextstate);
       if (!strm) {
-        LOG(ERROR) << "VectorFst::Read: Read failed: " << opts.source;
+        LOG(ERROR) << "VectorFst::Read: Arc read failed: " << opts.source;
         return nullptr;
       }
       impl->BaseImpl::AddArc(state, std::move(arc));

--- a/src/include/fst/weight.h
+++ b/src/include/fst/weight.h
@@ -37,8 +37,8 @@
 #include <fst/log.h>
 #include <fst/util.h>
 
-DECLARE_string(fst_weight_parentheses);
-DECLARE_string(fst_weight_separator);
+DECLARE_export_string(fst_weight_parentheses, fst_EXPORT);
+DECLARE_export_string(fst_weight_separator, fst_EXPORT);
 
 namespace fst {
 
@@ -271,7 +271,7 @@ struct WeightGenerate {
 
 namespace internal {
 
-class CompositeWeightIO {
+class fst_EXPORT CompositeWeightIO {
  public:
   CompositeWeightIO();
   CompositeWeightIO(char separator, std::pair<char, char> parentheses);
@@ -295,7 +295,7 @@ class CompositeWeightIO {
 }  // namespace internal
 
 // Helper class for writing textual composite weights.
-class CompositeWeightWriter : public internal::CompositeWeightIO {
+class fst_EXPORT CompositeWeightWriter : public internal::CompositeWeightIO {
  public:
   // Uses configuration from flags (FST_FLAGS_fst_weight_separator,
   // FST_FLAGS_fst_weight_parentheses).
@@ -331,7 +331,7 @@ class CompositeWeightWriter : public internal::CompositeWeightIO {
 // a separator character. There must be at least one element per textual
 // representation. Parentheses characters should be set if the composite
 // weights themselves contain composite weights to ensure proper parsing.
-class CompositeWeightReader : public internal::CompositeWeightIO {
+class fst_EXPORT CompositeWeightReader : public internal::CompositeWeightIO {
  public:
   // Uses configuration from flags (FST_FLAGS_fst_weight_separator,
   // FST_FLAGS_fst_weight_parentheses).

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,0 +1,41 @@
+
+
+add_library(fst
+  SHARED
+  compat.cc
+  encode.cc
+  flags.cc
+  fst-types.cc
+  fst.cc
+  mapped-file.cc
+  properties.cc
+  symbol-table.cc
+  symbol-table-ops.cc
+  util.cc
+  weight.cc
+)
+if (MSVC)
+GENERATE_EXPORT_HEADER( fst
+             BASE_NAME fst
+             EXPORT_MACRO_NAME fst_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fst_Export.h
+             STATIC_DEFINE fst_BUILT_AS_STATIC
+)
+endif()
+set_target_properties(fst PROPERTIES
+  SOVERSION "${SOVERSION}"
+)
+target_include_directories(fst PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+target_include_directories(fst PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+target_link_libraries(fst ${CMAKE_DL_LIBS})
+target_compile_definitions(fst PRIVATE fst_EXPORTS)
+
+
+
+install(TARGETS fst
+LIBRARY DESTINATION lib
+ARCHIVE DESTINATION lib
+RUNTIME DESTINATION bin
+  )

--- a/src/lib/flags.cc
+++ b/src/lib/flags.cc
@@ -28,6 +28,13 @@
 
 #include <fst/log.h>
 
+#ifdef _WIN32
+FlagSingleton& GetFlagSingleton() {
+    static FlagSingleton _instance;
+    return _instance;
+};
+#endif
+
 static const char *private_tmpdir = getenv("TMPDIR");
 
 DEFINE_int32(v, 0, "verbosity level");

--- a/src/lib/fst-types.cc
+++ b/src/lib/fst-types.cc
@@ -28,6 +28,13 @@
 
 namespace fst {
 
+#if defined(_WIN32) || defined(__APPLE__)
+Singleton& GetSingleton() {
+    static Singleton _instance;
+    return _instance;
+};
+#endif
+
 REGISTER_FST(VectorFst, StdArc);
 REGISTER_FST(VectorFst, LogArc);
 REGISTER_FST(VectorFst, Log64Arc);

--- a/src/lib/fst.cc
+++ b/src/lib/fst.cc
@@ -31,6 +31,9 @@
 #include <fst/util.h>
 #include <string_view>
 
+#include <fst/cache.h>
+#include <fst/lookahead-matcher.h>
+
 // FST flag definitions.
 
 DEFINE_bool(fst_verify_properties, false,

--- a/src/lib/symbol-table.cc
+++ b/src/lib/symbol-table.cc
@@ -345,7 +345,7 @@ void SymbolTableImpl::ShrinkToFit() { symbols_.ShrinkToFit(); }
 
 SymbolTable * SymbolTable::ReadText(const std::string &source,
                                                     const std::string &sep) {
-  std::ifstream strm(source, std::ios_base::in);
+  std::ifstream strm(source, std::ios_base::in | std::ios_base::binary);
   if (!strm.good()) {
     LOG(ERROR) << "SymbolTable::ReadText: Can't open file: " << source;
     return nullptr;
@@ -383,7 +383,7 @@ bool SymbolTable::WriteText(std::ostream &strm, const std::string &sep) const {
 bool SymbolTable::WriteText(const std::string &sink,
                             const std::string &sep) const {
   if (!sink.empty()) {
-    std::ofstream strm(sink);
+    std::ofstream strm(sink, std::ios_base::out | std::ios_base::binary);
     if (!strm) {
       LOG(ERROR) << "SymbolTable::WriteText: Can't open file: " << sink;
       return false;

--- a/src/script/CMakeLists.txt
+++ b/src/script/CMakeLists.txt
@@ -1,0 +1,75 @@
+
+    add_library(fstscript
+      arciterator-class.cc
+      stateiterator-class.cc
+      weight-class.cc
+      draw.cc
+      getters.cc
+      print.cc
+      text-io.cc
+      arcsort.cc
+      closure.cc
+      fst-class.cc
+      info.cc
+      info-impl.cc
+      verify.cc
+      map.cc
+      compile.cc
+      compose.cc
+      concat.cc
+      connect.cc
+      convert.cc
+      randequivalent.cc
+      randgen.cc
+      topsort.cc
+      union.cc
+      equal.cc
+      equivalent.cc
+      intersect.cc
+      invert.cc
+      encode.cc
+      decode.cc
+      encodemapper-class.cc
+      determinize.cc
+      difference.cc
+      disambiguate.cc
+      epsnormalize.cc
+      isomorphic.cc
+      minimize.cc
+      project.cc
+      prune.cc
+      push.cc
+      relabel.cc
+      replace.cc
+      reverse.cc
+      reweight.cc
+      rmepsilon.cc
+      shortest-distance.cc
+      shortest-path.cc
+      synchronize.cc
+    )
+
+if (MSVC) # Fix for too many exported symbols in fstscript
+  
+GENERATE_EXPORT_HEADER( fstscript
+             BASE_NAME fstscript
+             EXPORT_MACRO_NAME fstscript_EXPORT
+             EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/include/fst/exports/fstscript_Export.h
+             STATIC_DEFINE fstscript_BUILT_AS_STATIC
+)
+target_include_directories(fstscript PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+target_compile_definitions(fstscript PRIVATE fstscript_EXPORTS)
+    else()
+
+endif()
+    target_link_libraries(fstscript PUBLIC fst)
+target_include_directories(fstscript PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                           $<INSTALL_INTERFACE:include>)
+set_target_properties(fstscript PROPERTIES
+  SOVERSION "${SOVERSION}"
+)
+install(TARGETS fstscript
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/src/script/text-io.cc
+++ b/src/script/text-io.cc
@@ -37,7 +37,7 @@ namespace script {
 // Reads vector of weights; returns true on success.
 bool ReadPotentials(std::string_view weight_type, const std::string &source,
                     std::vector<WeightClass> *potentials) {
-  std::ifstream istrm(source);
+  std::ifstream istrm(source, std::ios_base::in | std::ios_base::binary);
   if (!istrm) {
     LOG(ERROR) << "ReadPotentials: Can't open file: " << source;
     return false;
@@ -71,7 +71,7 @@ bool WritePotentials(const std::string &source,
                      const std::vector<WeightClass> &potentials) {
   std::ofstream ostrm;
   if (!source.empty()) {
-    ostrm.open(source);
+    ostrm.open(source, std::ios_base::out | std::ios_base::binary);
     if (!ostrm) {
       LOG(ERROR) << "WritePotentials: Can't open file: " << source;
       return false;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,0 +1,185 @@
+
+add_executable(fst_test
+        fst_test.cc
+        ../include/fst/test/compactors.h
+        ../include/fst/test/fst_test.h
+        )
+
+target_link_libraries(fst_test fst)
+if (MSVC)
+        set_target_properties(fst_test 
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "TMPDIR=${CMAKE_BINARY_DIR}/tmp"
+        )
+elseif (APPLE)
+        set_target_properties(fst_test 
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+else()
+        set_target_properties(fst_test 
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+endif()
+add_test(NAME fst_test_test COMMAND fst_test --tmpdir=${CMAKE_BINARY_DIR}/tmp WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/lib)
+
+add_executable(weight_test
+        weight_test.cc
+        ../include/fst/test/weight-tester.h
+        )
+target_link_libraries(weight_test fst ${CMAKE_DL_LIBS})
+if (MSVC)
+        set_target_properties(weight_test 
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "PATH=${test_dll_path}"
+        )
+elseif (APPLE)
+        set_target_properties(weight_test
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+else()
+        set_target_properties(weight_test
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+endif()
+add_test(NAME weight_test_test COMMAND weight_test WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/lib)
+
+
+add_executable(algo_test_log algo_test.cc ../include/fst/test/algo_test.h ../include/fst/test/rand-fst.h)
+target_link_libraries(algo_test_log fst ${CMAKE_DL_LIBS})
+target_compile_definitions(algo_test_log
+        PRIVATE TEST_LOG=1)
+if (MSVC)
+        set_target_properties(algo_test_log 
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "PATH=${test_dll_path}"
+        )
+elseif (APPLE)
+        set_target_properties(algo_test_log
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+else()
+        set_target_properties(algo_test_log
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+endif()
+add_test(NAME algo_test_log_test COMMAND algo_test_log WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/lib)
+
+
+add_executable(algo_test_tropical algo_test.cc ../include/fst/test/algo_test.h ../include/fst/test/rand-fst.h)
+target_link_libraries(algo_test_tropical fst ${CMAKE_DL_LIBS})
+target_compile_definitions(algo_test_tropical
+        PRIVATE TEST_TROPICAL=1)
+
+if (MSVC)
+        set_target_properties(algo_test_tropical 
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "PATH=${test_dll_path}"
+        )
+elseif (APPLE)
+        set_target_properties(algo_test_tropical
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+else()
+        set_target_properties(algo_test_tropical
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+endif()
+add_test(NAME algo_test_tropical_test COMMAND algo_test_tropical WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/lib)
+
+
+add_executable(algo_test_minmax algo_test.cc ../include/fst/test/algo_test.h ../include/fst/test/rand-fst.h)
+target_link_libraries(algo_test_minmax fst ${CMAKE_DL_LIBS})
+target_compile_definitions(algo_test_minmax
+        PRIVATE TEST_MINMAX=1)
+if (MSVC)
+        set_target_properties(algo_test_minmax 
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "PATH=${test_dll_path}"
+        )
+elseif (APPLE)
+        set_target_properties(algo_test_minmax
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+else()
+        set_target_properties(algo_test_minmax
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+endif()
+add_test(NAME algo_test_minmax_test COMMAND algo_test_minmax WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/lib)
+
+
+add_executable(algo_test_lexicographic algo_test.cc ../include/fst/test/algo_test.h ../include/fst/test/rand-fst.h)
+target_link_libraries(algo_test_lexicographic fst ${CMAKE_DL_LIBS})
+target_compile_definitions(algo_test_lexicographic
+        PRIVATE TEST_LEXICOGRAPHIC=1)
+if (MSVC)
+        set_target_properties(algo_test_lexicographic 
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "PATH=${test_dll_path}"
+        )
+elseif (APPLE)
+        set_target_properties(algo_test_lexicographic
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+else()
+        set_target_properties(algo_test_lexicographic
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+endif()
+add_test(NAME algo_test_lexicographic_test COMMAND algo_test_lexicographic WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/lib)
+
+
+add_executable(algo_test_power algo_test.cc ../include/fst/test/algo_test.h ../include/fst/test/rand-fst.h)
+target_link_libraries(algo_test_power fst ${CMAKE_DL_LIBS})
+target_compile_definitions(algo_test_power
+        PRIVATE TEST_POWER=1)
+if (MSVC)
+        set_target_properties(algo_test_power 
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "PATH=${test_dll_path}"
+        )
+elseif (APPLE)
+        set_target_properties(algo_test_power
+                PROPERTIES  
+                        FOLDER test 
+                        ENVIRONMENT "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+else()
+        set_target_properties(algo_test_power
+                PROPERTIES 
+                        FOLDER test 
+                        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib;${CMAKE_INSTALL_PREFIX}/lib"
+        )
+endif()
+add_test(NAME algo_test_power_test COMMAND algo_test_power WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/lib)


### PR DESCRIPTION
Changes:

* Added header files for exporting symbols on window, along with updating declarations to include the relevant export macro for the library (i.e. `fst_EXPORT`, `fstscript_EXPORT`, etc)
* Created singletons of flag and fst registers, since both Windows and OSX were reporting not finding `vector-fst.{dll,dylib}` when running fst_test.  I'm not sure if this is the best pattern or if it's fixable some other way, but it works.
* Ensured that all fstreams are opened with `std::ios_base::binary` to ensure consistent line endings for text files across platforms
* Added Windows specific code for adding the binary mode to stdin/stdout
* Changed module loading for new arc types etc to use `.dll` or `.dylib` rather than `.so`